### PR TITLE
Bound osascript send with a timeout so a wedged Messages bridge can't hang requests

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,7 +16,8 @@ func loadConfig(configPath string) (*Config, error) {
 	if configPath == "" {
 		return &Config{
 			Messages: MessagesConfig{
-				Groups: make(map[string][]string),
+				Groups:         make(map[string][]string),
+				TimeoutSeconds: defaultSendTimeoutSeconds,
 			},
 			Storage: StorageConfig{
 				Dir: "./storage", // Default storage directory
@@ -44,6 +45,11 @@ func loadConfig(configPath string) (*Config, error) {
 	// Set default storage directory if not specified
 	if config.Storage.Dir == "" {
 		config.Storage.Dir = "./storage"
+	}
+
+	// Set default send timeout if not specified or invalid
+	if config.Messages.TimeoutSeconds <= 0 {
+		config.Messages.TimeoutSeconds = defaultSendTimeoutSeconds
 	}
 
 	log.Printf("Configuration loaded from %s with %d message groups and storage dir: %s", configPath, len(config.Messages.Groups), config.Storage.Dir)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -2,6 +2,11 @@
 # Copy this file to config.yaml and modify as needed
 
 messages:
+  # Max seconds a single osascript send may run before it is killed and
+  # reported as a failure. Defaults to 7 if unset. Keep it well under the
+  # ~120s default AppleEvent timeout so a wedged Messages bridge fails fast,
+  # and below any synchronous client's read timeout (the doorbell uses 10s).
+  timeout_seconds: 7
   groups:
     developers:
       - "dev1@example.com"

--- a/messages.go
+++ b/messages.go
@@ -1,15 +1,24 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
 	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/labstack/echo/v4"
 )
+
+// defaultSendTimeoutSeconds bounds a single osascript send. It is intentionally
+// well under the ~120s default AppleEvent timeout so a wedged Messages bridge
+// fails fast instead of hanging the HTTP request. Kept below the doorbell
+// client's 10s read timeout (7 + 2s grace = 9s) so mowa fails before the client
+// gives up.
+const defaultSendTimeoutSeconds = 7
 
 // @Summary Send messages to recipients
 // @Description Send messages to one or more recipients via iMessage
@@ -90,24 +99,49 @@ func sendMessage(recipient, message string) error {
 	// Escape the message content for AppleScript
 	escapedMessage := strings.ReplaceAll(message, "\"", "\\\"")
 
-	// Create AppleScript to send message via Messages app
+	timeout := sendTimeout()
+
+	// Create AppleScript to send message via Messages app. The `with timeout`
+	// block makes the AppleEvent surface a clean error faster than its ~120s
+	// default; executeAppleScript enforces a hard deadline as a backstop.
 	script := fmt.Sprintf(`
-tell application "Messages"
-    set targetService to 1st service whose service type = iMessage
-    set myBuddy to buddy "%s" of targetService
-    send "%s" to myBuddy
-end tell
-`, recipient, escapedMessage)
+with timeout of %d seconds
+    tell application "Messages"
+        set targetService to 1st service whose service type = iMessage
+        set myBuddy to buddy "%s" of targetService
+        send "%s" to myBuddy
+    end tell
+end timeout
+`, int(timeout.Seconds()), recipient, escapedMessage)
 
 	// Execute the AppleScript
-	return executeAppleScript(script)
+	return executeAppleScript(script, timeout)
 }
 
-// executeAppleScript executes an AppleScript and returns any error
-func executeAppleScript(script string) error {
-	cmd := exec.Command("osascript", "-e", script)
+// sendTimeout returns the configured osascript send timeout, falling back to
+// the default when no config has been loaded or the value is invalid.
+func sendTimeout() time.Duration {
+	if appConfig != nil && appConfig.Messages.TimeoutSeconds > 0 {
+		return time.Duration(appConfig.Messages.TimeoutSeconds) * time.Second
+	}
+	return defaultSendTimeoutSeconds * time.Second
+}
+
+// executeAppleScript executes an AppleScript with a bounded deadline and returns
+// any error. The process is killed on timeout so no orphaned osascript lingers.
+func executeAppleScript(script string, timeout time.Duration) error {
+	// Give the process a small grace period beyond the AppleScript's own
+	// `with timeout` so its cleaner error can surface before the hard kill.
+	ctx, cancel := context.WithTimeout(context.Background(), timeout+2*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "osascript", "-e", script)
 
 	output, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		log.Printf("AppleScript timed out after %s; killed osascript", timeout)
+		return fmt.Errorf("osascript timed out after %s", timeout)
+	}
 	if err != nil {
 		log.Printf("AppleScript failed with error: %v", err)
 		log.Printf("AppleScript output: %s", string(output))

--- a/messages_test.go
+++ b/messages_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestExecuteAppleScriptSuccess verifies a trivial script returns quickly with no error.
+func TestExecuteAppleScriptSuccess(t *testing.T) {
+	start := time.Now()
+	if err := executeAppleScript(`return "ok"`, 15*time.Second); err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("trivial send took %s, expected well under a second", elapsed)
+	}
+}
+
+// TestExecuteAppleScriptTimeout simulates a hung Messages bridge with `delay` and
+// confirms the call fails fast with a timeout error instead of blocking.
+func TestExecuteAppleScriptTimeout(t *testing.T) {
+	start := time.Now()
+	err := executeAppleScript(`delay 30`, 1*time.Second)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected a timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expected a timeout error, got: %v", err)
+	}
+	// context deadline is timeout + 2s grace = ~3s; allow slack for CI.
+	if elapsed > 8*time.Second {
+		t.Errorf("timeout took %s, expected it to fail fast (~3s)", elapsed)
+	}
+}

--- a/models.go
+++ b/models.go
@@ -9,6 +9,9 @@ type Config struct {
 // MessagesConfig represents the messages configuration
 type MessagesConfig struct {
 	Groups map[string][]string `yaml:"groups"`
+	// TimeoutSeconds bounds how long a single osascript send may run before
+	// it is killed and reported as a failure. Defaults to defaultSendTimeoutSeconds.
+	TimeoutSeconds int `yaml:"timeout_seconds"`
 }
 
 // StorageConfig represents the storage configuration


### PR DESCRIPTION
Closes #7.

## Problem

`POST /api/messages` shelled out to `osascript` synchronously with no timeout, relying on the ~120s default AppleEvent timeout. The Messages AppleScript bridge intermittently wedges (observed in testing: a full 120s hang, AppleEvent `timed out -1712`), which blocked the HTTP request for up to ~2 minutes — well past the doorbell client's 10s read timeout.

## Change

- Run `osascript` under `exec.CommandContext` + `context.WithTimeout`; the process is killed on timeout, so no orphaned `osascript` lingers.
- Wrap the AppleScript body in `with timeout of N seconds … end timeout` so the AppleEvent surfaces a clean error faster than its ~120s default. The Go context deadline is `N + 2s` (grace) as a hard backstop.
- On timeout, return a timeout error that flows into the existing per-recipient result (`results[].success=false`), consistent with other send failures. **API contract and success path unchanged.**
- Configurable via `messages.timeout_seconds` in `config.yaml` (new `MessagesConfig.TimeoutSeconds`), **default 7s** — sits below the doorbell's 10s read timeout (7 + 2s grace = 9s) so mowa fails before the client gives up.

## Verification

New `messages_test.go` uses harmless `return "ok"` / `delay 30` scripts (never touches the Messages bridge):

- Success path completes in ~0.06s (well under a second).
- Hang simulation (`delay 30`, 1s timeout) fails in ~3s with a timeout error instead of blocking.
- `pgrep osascript` after a forced timeout returns 0 processes (no orphans).

`go build` and `go test ./...` pass locally on macOS.

## Note for reviewer

If the doorbell's 10s read timeout ever changes, revisit `timeout_seconds` (and vice versa) so the two windows stay coordinated.
