### PR TITLE
Add endpoint to install and start the launchd service

### DIFF
--- a/main.go
+++ b/main.go
@@ -247,6 +247,9 @@ func main() {
 
 		// Self-update endpoint
 		api.POST("/update", handleUpdate)
+
+		// Service endpoint - install/start mowa as a launchd service
+		api.POST("/service", handleService)
 	}
 
 	// Start server

--- a/models.go
+++ b/models.go
@@ -114,6 +114,56 @@ type UpdateResponse struct {
 	Error string `json:"error,omitempty"`
 }
 
+// ServiceRequest represents the request to install mowa as a launchd service.
+// All fields are optional; omitted fields fall back to their defaults.
+// @Description Request to install and start mowa as a launchd service
+type ServiceRequest struct {
+	// @Description Absolute path to the mowa binary launchd should run
+	// @Example "/usr/local/bin/mowa"
+	BinaryPath string `json:"binary_path,omitempty"`
+	// @Description Path to the config file passed to mowa via -config (a leading ~ is expanded)
+	// @Example "~/Library/Application Support/mowa/config.yaml"
+	ConfigPath string `json:"config_path,omitempty"`
+	// @Description Path for the service's standard output log (a leading ~ is expanded)
+	// @Example "~/Library/Logs/mowa.out"
+	StdoutLog string `json:"stdout_log,omitempty"`
+	// @Description Path for the service's standard error log (a leading ~ is expanded)
+	// @Example "~/Library/Logs/mowa.err"
+	StderrLog string `json:"stderr_log,omitempty"`
+}
+
+// ServiceStep records the outcome of a single launchctl invocation.
+// @Description Outcome of one launchctl command run while loading the service
+type ServiceStep struct {
+	// @Description The launchctl command that was run
+	// @Example "launchctl bootstrap gui/501 /Users/me/Library/LaunchAgents/com.mauromorales.mowa.plist"
+	Command string `json:"command"`
+	// @Description Combined stdout/stderr output of the command
+	Output string `json:"output,omitempty"`
+	// @Description Error message if the command failed
+	Error string `json:"error,omitempty"`
+}
+
+// ServiceResponse represents the response from installing the launchd service.
+// @Description Response from installing and starting the launchd service
+type ServiceResponse struct {
+	// @Description Whether the plist was written and the service loaded successfully
+	Success bool `json:"success"`
+	// @Description Absolute path of the plist that was written
+	// @Example "/Users/me/Library/LaunchAgents/com.mauromorales.mowa.plist"
+	PlistPath string `json:"plistPath,omitempty"`
+	// @Description The launchd label for the service
+	// @Example "com.mauromorales.mowa"
+	Label string `json:"label,omitempty"`
+	// @Description The launchctl commands that were run and their outcomes
+	Steps []ServiceStep `json:"steps,omitempty"`
+	// @Description Human-readable description of the result
+	// @Example "launchd service installed and started"
+	Message string `json:"message"`
+	// @Description Error message if the operation failed
+	Error string `json:"error,omitempty"`
+}
+
 // MowaError represents custom errors
 // @Description Custom error response
 type MowaError struct {

--- a/service.go
+++ b/service.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"html"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+// launchd service constants. The label is fixed so the plist, the launchctl
+// service target, and the self-restart logic all agree on the same identity.
+const (
+	launchdLabel = "com.mauromorales.mowa"
+
+	// defaultBinaryPath is where a `brew`/manual install typically drops mowa.
+	defaultBinaryPath = "/usr/local/bin/mowa"
+
+	// launchctlTimeout bounds each launchctl invocation so a wedged launchd
+	// can't hang the HTTP request.
+	launchctlTimeout = 10 * time.Second
+
+	// serviceRestartDelay gives the HTTP response a moment to flush before the
+	// service is restarted (via kickstart) when this very process is the one
+	// launchd manages.
+	serviceRestartDelay = 500 * time.Millisecond
+)
+
+// pidLineRegexp extracts the running pid from `launchctl print` output, whose
+// service dump contains a line like "\tpid = 1234".
+var pidLineRegexp = regexp.MustCompile(`(?m)^\s*pid = (\d+)`)
+
+// @Summary Install and start mowa as a launchd service
+// @Description Generates the launchd agent plist for mowa, writes it to ~/Library/LaunchAgents/com.mauromorales.mowa.plist (overwriting any existing one), and loads + starts the service via launchctl so mowa runs at login and stays alive (KeepAlive).
+// @Description
+// @Description All four fields are optional; omitted fields fall back to the defaults shown. A leading "~" in any path is expanded to the current user's home directory, and the plist always uses absolute, home-resolved paths.
+// @Description
+// @Description Idempotent: calling it repeatedly re-writes the plist and reloads the service. If the label is already loaded under a different process it is booted out and bootstrapped again.
+// @Description
+// @Description Caveats:
+// @Description - If the mowa handling this request is itself the launchd-managed instance, the plist is refreshed and the service is restarted via `launchctl kickstart -k` shortly after the response is sent, so the connection may drop as the service restarts.
+// @Description - If the mowa handling this request is NOT running under launchd (e.g. started with `make run`), bootstrapping spawns a separate instance under launchd. If both bind the same port, the launchd instance fails to start (and KeepAlive keeps retrying); the response flags this so it is visible instead of looping silently.
+// @Tags system
+// @Accept json
+// @Produce json
+// @Param request body ServiceRequest false "Service configuration (empty body uses all defaults)"
+// @Success 200 {object} ServiceResponse "Service installed and started (or restarting)"
+// @Failure 400 {object} ServiceResponse "Bad request - invalid body"
+// @Failure 500 {object} ServiceResponse "Failed to write the plist or load the service"
+// @Router /api/service [post]
+func handleService(c echo.Context) error {
+	var req ServiceRequest
+	// An empty body is valid (use all defaults). Echo surfaces that as io.EOF.
+	if err := c.Bind(&req); err != nil && !errors.Is(err, io.EOF) {
+		return c.JSON(http.StatusBadRequest, ServiceResponse{
+			Success: false,
+			Message: "invalid request body",
+			Error:   err.Error(),
+		})
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, ServiceResponse{
+			Success: false,
+			Message: "could not resolve the current user's home directory",
+			Error:   err.Error(),
+		})
+	}
+
+	binaryPath := resolveServicePath(req.BinaryPath, defaultBinaryPath, home)
+	configPath := resolveServicePath(req.ConfigPath, filepath.Join(home, "Library", "Application Support", "mowa", "config.yaml"), home)
+	stdoutLog := resolveServicePath(req.StdoutLog, filepath.Join(home, "Library", "Logs", "mowa.out"), home)
+	stderrLog := resolveServicePath(req.StderrLog, filepath.Join(home, "Library", "Logs", "mowa.err"), home)
+
+	// Ensure the directories launchd and the config file need exist. The config
+	// file itself is left absent on purpose: loadConfig falls back to defaults
+	// when it is missing, so we must not create or overwrite it here.
+	launchAgentsDir := filepath.Join(home, "Library", "LaunchAgents")
+	for _, dir := range []string{launchAgentsDir, filepath.Dir(configPath), filepath.Dir(stdoutLog), filepath.Dir(stderrLog)} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return c.JSON(http.StatusInternalServerError, ServiceResponse{
+				Success: false,
+				Message: fmt.Sprintf("failed to create directory %s", dir),
+				Error:   err.Error(),
+			})
+		}
+	}
+
+	plistPath := filepath.Join(launchAgentsDir, launchdLabel+".plist")
+	plist := renderLaunchdPlist(binaryPath, configPath, stdoutLog, stderrLog)
+	if err := os.WriteFile(plistPath, []byte(plist), 0644); err != nil {
+		return c.JSON(http.StatusInternalServerError, ServiceResponse{
+			Success:   false,
+			PlistPath: plistPath,
+			Label:     launchdLabel,
+			Message:   "failed to write the launchd plist",
+			Error:     err.Error(),
+		})
+	}
+
+	uid := os.Getuid()
+	domainTarget := fmt.Sprintf("gui/%d", uid)
+	serviceTarget := fmt.Sprintf("gui/%d/%s", uid, launchdLabel)
+	selfPID := os.Getpid()
+
+	prevPID, wasLoaded := servicePID(serviceTarget)
+
+	resp := ServiceResponse{PlistPath: plistPath, Label: launchdLabel}
+
+	// Case 1: this very process is the launchd-managed instance. Booting it out
+	// would kill us mid-request, so refresh the plist (already done above) and
+	// restart in place with kickstart -k after the response has flushed.
+	if wasLoaded && prevPID == selfPID {
+		resp.Success = true
+		resp.Message = "plist updated; this process is the launchd-managed service and will restart to apply changes (the connection may drop)"
+		writeErr := c.JSON(http.StatusOK, resp)
+		if writeErr != nil {
+			log.Printf("failed to write service response, restarting anyway: %v", writeErr)
+		}
+		log.Printf("🔄 Refreshed launchd plist; restarting %s via kickstart", serviceTarget)
+		go func() {
+			time.Sleep(serviceRestartDelay)
+			if err := exec.Command("launchctl", "kickstart", "-k", serviceTarget).Run(); err != nil {
+				log.Printf("kickstart of %s failed: %v", serviceTarget, err)
+			}
+		}()
+		return writeErr
+	}
+
+	// Case 2: the label is loaded under a different process (or not loaded at
+	// all). Unload any existing instance, then bootstrap from the fresh plist.
+	var steps []ServiceStep
+	if wasLoaded {
+		steps = append(steps, runLaunchctl("bootout", serviceTarget))
+	}
+	bootstrap := runLaunchctl("bootstrap", domainTarget, plistPath)
+	steps = append(steps, bootstrap)
+	resp.Steps = steps
+
+	if bootstrap.Error != "" {
+		resp.Success = false
+		resp.Message = "failed to bootstrap the launchd service"
+		resp.Error = bootstrap.Error
+		return c.JSON(http.StatusInternalServerError, resp)
+	}
+
+	resp.Success = true
+	resp.Message = "launchd service installed and started"
+
+	// If the freshly loaded service runs under a different pid than the caller,
+	// the caller is not the launchd-managed instance (e.g. a `make run` process).
+	// Flag the likely port conflict instead of letting KeepAlive loop silently.
+	if newPID, ok := servicePID(serviceTarget); ok && newPID != 0 && newPID != selfPID {
+		resp.Message += fmt.Sprintf(
+			"; note: the mowa handling this request (pid %d) is not the launchd-managed instance (pid %d) — if both bind the same port the launchd instance will fail to start and KeepAlive will keep retrying",
+			selfPID, newPID,
+		)
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+// resolveServicePath returns the trimmed value (or the fallback when empty) with
+// a leading "~" expanded to the user's home directory.
+func resolveServicePath(value, fallback, home string) string {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		v = fallback
+	}
+	return expandHome(v, home)
+}
+
+// expandHome expands a leading "~" or "~/" in path to the given home directory.
+func expandHome(path, home string) string {
+	if path == "~" {
+		return home
+	}
+	if strings.HasPrefix(path, "~/") {
+		return filepath.Join(home, path[2:])
+	}
+	return path
+}
+
+// renderLaunchdPlist builds the launchd agent plist. Path values are XML-escaped
+// so a path containing "&" or "<" cannot corrupt the document.
+func renderLaunchdPlist(binaryPath, configPath, stdoutLog, stderrLog string) string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>%s</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>%s</string>
+        <string>-config</string>
+        <string>%s</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>%s</string>
+    <key>StandardErrorPath</key>
+    <string>%s</string>
+</dict>
+</plist>
+`,
+		html.EscapeString(launchdLabel),
+		html.EscapeString(binaryPath),
+		html.EscapeString(configPath),
+		html.EscapeString(stdoutLog),
+		html.EscapeString(stderrLog),
+	)
+}
+
+// servicePID reports whether the service target is loaded and, if it is running,
+// its pid. A non-zero launchctl exit means the service is not loaded. A loaded
+// but idle service returns (0, true).
+func servicePID(serviceTarget string) (int, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), launchctlTimeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "launchctl", "print", serviceTarget).CombinedOutput()
+	if err != nil {
+		return 0, false
+	}
+	m := pidLineRegexp.FindSubmatch(out)
+	if m == nil {
+		return 0, true
+	}
+	pid, err := strconv.Atoi(string(m[1]))
+	if err != nil {
+		return 0, true
+	}
+	return pid, true
+}
+
+// runLaunchctl runs a launchctl subcommand with a bounded deadline and captures
+// its combined output and any error as a reportable ServiceStep.
+func runLaunchctl(args ...string) ServiceStep {
+	ctx, cancel := context.WithTimeout(context.Background(), launchctlTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "launchctl", args...)
+	out, err := cmd.CombinedOutput()
+
+	step := ServiceStep{
+		Command: "launchctl " + strings.Join(args, " "),
+		Output:  strings.TrimSpace(string(out)),
+	}
+	switch {
+	case ctx.Err() == context.DeadlineExceeded:
+		step.Error = fmt.Sprintf("launchctl timed out after %s", launchctlTimeout)
+	case err != nil:
+		step.Error = err.Error()
+	}
+	return step
+}

--- a/service_test.go
+++ b/service_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExpandHome(t *testing.T) {
+	home := "/Users/test"
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"~", home},
+		{"~/Library/Logs/mowa.out", home + "/Library/Logs/mowa.out"},
+		{"/usr/local/bin/mowa", "/usr/local/bin/mowa"},
+		{"~notatilde/foo", "~notatilde/foo"}, // only a leading "~" or "~/" expands
+		{"relative/path", "relative/path"},
+	}
+	for _, tc := range cases {
+		if got := expandHome(tc.in, home); got != tc.want {
+			t.Errorf("expandHome(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestResolveServicePath(t *testing.T) {
+	home := "/Users/test"
+
+	// Empty value falls back to the default (with the default's ~ expanded).
+	if got := resolveServicePath("  ", "~/Library/Logs/mowa.out", home); got != home+"/Library/Logs/mowa.out" {
+		t.Errorf("empty value did not fall back to expanded default: %q", got)
+	}
+
+	// A provided value overrides the default and has its ~ expanded.
+	if got := resolveServicePath("~/custom.yaml", "/unused", home); got != home+"/custom.yaml" {
+		t.Errorf("provided value not expanded: %q", got)
+	}
+
+	// An absolute provided value is used verbatim.
+	if got := resolveServicePath("/opt/mowa", "/unused", home); got != "/opt/mowa" {
+		t.Errorf("absolute value changed: %q", got)
+	}
+}
+
+func TestRenderLaunchdPlist(t *testing.T) {
+	plist := renderLaunchdPlist("/usr/local/bin/mowa", "/Users/test/config.yaml", "/Users/test/out.log", "/Users/test/err.log")
+
+	for _, want := range []string{
+		"<key>Label</key>",
+		"<string>" + launchdLabel + "</string>",
+		"<string>/usr/local/bin/mowa</string>",
+		"<string>-config</string>",
+		"<string>/Users/test/config.yaml</string>",
+		"<key>RunAtLoad</key>",
+		"<key>KeepAlive</key>",
+		"<string>/Users/test/out.log</string>",
+		"<string>/Users/test/err.log</string>",
+	} {
+		if !strings.Contains(plist, want) {
+			t.Errorf("plist missing %q\n%s", want, plist)
+		}
+	}
+}
+
+func TestRenderLaunchdPlistEscapesPaths(t *testing.T) {
+	// A path with XML metacharacters must not break the document.
+	plist := renderLaunchdPlist("/opt/a&b/mowa", "/c<d>/config.yaml", "/out.log", "/err.log")
+	if strings.Contains(plist, "a&b") || strings.Contains(plist, "c<d>") {
+		t.Errorf("plist did not escape XML metacharacters:\n%s", plist)
+	}
+	if !strings.Contains(plist, "a&amp;b") || !strings.Contains(plist, "c&lt;d&gt;") {
+		t.Errorf("expected escaped metacharacters in plist:\n%s", plist)
+	}
+}


### PR DESCRIPTION
Closes #9.

Adds `POST /api/service`, which generates the launchd agent plist, installs it, and loads + starts the service so a running mowa instance can set itself up as a login service.

## What it does
- Writes the plist to `~/Library/LaunchAgents/com.mauromorales.mowa.plist` (overwriting for idempotency) and loads it with `launchctl bootstrap gui/$UID`.
- All four fields (`binary_path`, `config_path`, `stdout_log`, `stderr_log`) are optional and default to the conventional locations. A leading `~` is expanded to the **real current user's** home (never hardcoded); the plist always uses absolute, XML-escaped paths.
- Ensures `~/Library/LaunchAgents` and the parent dirs of the config/log paths exist, but never creates `config.yaml` itself — `loadConfig` already falls back to defaults when it's absent.
- Returns the resolved plist path, the label, and the outcome of each `launchctl` step so failures are visible; `launchctl` failures surface as a non-2xx response with the error output.

## Caveats handled
- **This process is the launchd-managed instance:** booting it out would kill the process mid-request, so it refreshes the plist and restarts via `launchctl kickstart -k` after the response flushes (connection may drop). Documented in the Swagger description.
- **Not running under launchd (e.g. `make run`):** bootstrapping spawns a separate instance; the response flags the likely same-port conflict (detected by comparing pids) instead of letting KeepAlive loop silently.
- All `launchctl` calls run with a bounded 10s timeout (following the osascript timeout pattern).

## Notes
- Independent of the self-update endpoint — uses its own `serviceRestartDelay` const rather than reusing `restartDelay`, so there's no coupling between the two features.
- Swagger docs regenerate at build time (the `docs/*` files are gitignored); the new endpoint/models are included.

## Testing
- `go vet`, `go test ./...`, and `make build` all pass. New unit tests cover `expandHome`, `resolveServicePath`, and plist rendering/XML-escaping.
- The live launchd install (bootstrap/`launchctl print` verification from the issue's acceptance criteria) was **not** run automatically, since it installs a persistent login agent on the machine. Worth a manual smoke test before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)