### PR TITLE
Add `mowa install` command to set up the launchd login service

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Go-native web API server that allows you to interact with MacOS and iCloud fea
 - **Send Messages**: Send iMessages via the Messages app using AppleScript
 - **System Uptime**: Get system uptime using shell commands
 - **File Storage**: Save and retrieve YAML files with configurable storage directory
+- **Login Service**: `mowa install` sets mowa up as a launchd agent that starts at login and stays alive
 - **Modular Architecture**: Easy to extend with new endpoints for volume control, app launching, etc.
 - **Go Native**: Single binary deployment, no external runtimes required
 - **High Performance**: Compiled Go with Echo web framework
@@ -70,6 +71,9 @@ go build -o mowa
 ./mowa -config config.yaml
 ```
 
+See [Installing as a Service](#installing-as-a-service) below to have mowa start
+automatically at login.
+
 ### 2. Test the API
 
 The server will start on `http://localhost:8080` by default. You can test it with:
@@ -127,67 +131,42 @@ curl -X GET http://localhost:8080/api/storage/config/database.yaml
 
 ## Installing as a Service
 
-To run mowa as a background service that starts automatically on system boot, you can create a LaunchDaemon plist file.
+Run `mowa install` to set mowa up as a launchd user agent that starts at login
+and stays alive (`KeepAlive`):
 
-1. **Create the plist file**:
-   ```bash
-   # Create the LaunchAgents directory if it doesn't exist
-   mkdir -p ~/Library/LaunchAgents
-   
-   # Create the plist file
-   cat > ~/Library/LaunchAgents/com.mauromorales.mowa.plist << 'EOF'
-   <?xml version="1.0" encoding="UTF-8"?>
-   <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-   <plist version="1.0">
-   <dict>
-       <key>Label</key>
-       <string>com.mauromorales.mowa</string>
-       <key>ProgramArguments</key>
-       <array>
-           <string>/path/to/your/mowa</string>
-           <string>-config</string>
-           <string>/path/to/your/config.yaml</string>
-       </array>
-       <key>RunAtLoad</key>
-       <true/>
-       <key>KeepAlive</key>
-       <true/>
-       <key>StandardOutPath</key>
-       <string>/Library/Logs/mowa.log</string>
-       <key>StandardErrorPath</key>
-       <string>/Library/Logs/mowa_error.log</string>
-       <key>WorkingDirectory</key>
-       <string>/path/to/your/mowa/directory</string>
-   </dict>
-   </plist>
-   EOF
-   ```
+```bash
+mowa install
+```
 
-2. **Update the paths** in the plist file:
-   - Replace `/path/to/your/mowa` with the actual path to your mowa binary
-   - Replace `/path/to/your/config.yaml` with the actual path to your config file
-   - Replace `/path/to/your/mowa/directory` with the directory containing your mowa binary
+This writes `~/Library/LaunchAgents/com.mauromorales.mowa.plist`, then loads and
+starts the service. By default it points the service at the binary you ran
+`install` from, uses `~/Library/Application Support/mowa/config.yaml` for
+configuration (the file is optional — mowa uses built-in defaults when it is
+absent), and logs to `~/Library/Logs/mowa.out` / `mowa.err`. Re-running
+`mowa install` reinstalls the service, so it is safe to run again after
+upgrading.
 
-3. **Load the service**:
-   ```bash
-   launchctl load ~/Library/LaunchAgents/com.mowa.plist
-   
-   # Check if it's running
-   launchctl list | grep mowa
-   ```
+Override any of the paths with flags:
 
-4. **Manage the service**:
-   ```bash
-   # Stop the service
-   launchctl stop com.mowa
-   
-   # Unload the service
-   launchctl unload ~/Library/LaunchAgents/com.mowa.plist
-   
-   # View logs
-   tail -f /Library/Logs/mowa.log
-   tail -f /Library/Logs/mowa_error.log
-   ```
+```bash
+mowa install \
+  --binary /usr/local/bin/mowa \
+  --config ~/Library/Application\ Support/mowa/config.yaml \
+  --stdout ~/Library/Logs/mowa.out \
+  --stderr ~/Library/Logs/mowa.err
+```
+
+Inspect, restart, or remove the service with `launchctl`:
+
+```bash
+launchctl print gui/$(id -u)/com.mauromorales.mowa    # inspect
+launchctl kickstart -k gui/$(id -u)/com.mauromorales.mowa  # restart
+launchctl bootout gui/$(id -u)/com.mauromorales.mowa  # stop and unload
+tail -f ~/Library/Logs/mowa.out                       # view logs
+```
+
+Running mowa under launchd is also what lets the `POST /api/update` self-update
+endpoint relaunch the process on the new binary.
 
 ## API Documentation
 

--- a/README.md
+++ b/README.md
@@ -147,14 +147,21 @@ absent), and logs to `~/Library/Logs/mowa.out` / `mowa.err`. Re-running
 `mowa install` reinstalls the service, so it is safe to run again after
 upgrading.
 
-Override any of the paths with flags:
+The service's port follows `MOWA_PORT`: pass `--port` (or have `MOWA_PORT` set in
+your environment when you run `install`) and it is written into the plist's
+`EnvironmentVariables`. Without either, the service uses mowa's built-in default
+(8080) — note the service does **not** inherit a `MOWA_PORT` you export in your
+shell later, only what is captured at install time.
+
+Override any of the paths (and the port) with flags:
 
 ```bash
 mowa install \
   --binary /usr/local/bin/mowa \
   --config ~/Library/Application\ Support/mowa/config.yaml \
   --stdout ~/Library/Logs/mowa.out \
-  --stderr ~/Library/Logs/mowa.err
+  --stderr ~/Library/Logs/mowa.err \
+  --port 3000
 ```
 
 Inspect, restart, or remove the service with `launchctl`:

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -10,24 +11,38 @@ import (
 
 var appConfig *Config
 
+// defaultConfig returns the built-in configuration used when no config file is
+// present.
+func defaultConfig() *Config {
+	return &Config{
+		Messages: MessagesConfig{
+			Groups:         make(map[string][]string),
+			TimeoutSeconds: defaultSendTimeoutSeconds,
+		},
+		Storage: StorageConfig{
+			Dir: "./storage", // Default storage directory
+		},
+	}
+}
+
 // loadConfig loads configuration from a YAML file
 func loadConfig(configPath string) (*Config, error) {
-	// If no config path provided, return default empty config
+	// If no config path provided, return the default config.
 	if configPath == "" {
-		return &Config{
-			Messages: MessagesConfig{
-				Groups:         make(map[string][]string),
-				TimeoutSeconds: defaultSendTimeoutSeconds,
-			},
-			Storage: StorageConfig{
-				Dir: "./storage", // Default storage directory
-			},
-		}, nil
+		return defaultConfig(), nil
 	}
 
 	// Read config file
 	data, err := os.ReadFile(configPath)
 	if err != nil {
+		// A missing config file is not an error: fall back to defaults so a
+		// service pointed at a not-yet-created config (e.g. the launchd agent
+		// installed by `mowa install`) still starts. Other read errors such as
+		// bad permissions are real and surfaced to the caller.
+		if errors.Is(err, os.ErrNotExist) {
+			log.Printf("Config file %s not found; using defaults", configPath)
+			return defaultConfig(), nil
+		}
 		return nil, fmt.Errorf("failed to read config file %s: %w", configPath, err)
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadConfigMissingFileFallsBackToDefaults ensures a config path that does
+// not exist yields the default config rather than an error, so the launchd
+// service (which is pointed at a possibly-absent config.yaml) still starts.
+func TestLoadConfigMissingFileFallsBackToDefaults(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+
+	cfg, err := loadConfig(missing)
+	if err != nil {
+		t.Fatalf("expected defaults for a missing file, got error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected a config, got nil")
+	}
+	if cfg.Storage.Dir != "./storage" {
+		t.Errorf("expected default storage dir, got %q", cfg.Storage.Dir)
+	}
+	if cfg.Messages.TimeoutSeconds != defaultSendTimeoutSeconds {
+		t.Errorf("expected default timeout %d, got %d", defaultSendTimeoutSeconds, cfg.Messages.TimeoutSeconds)
+	}
+	if cfg.Messages.Groups == nil {
+		t.Error("expected an initialized (non-nil) groups map")
+	}
+}
+
+// TestLoadConfigUnreadableFileErrors ensures a real read error (not "missing")
+// is still surfaced instead of being masked as a fallback to defaults.
+func TestLoadConfigUnreadableFileErrors(t *testing.T) {
+	// A directory can't be read as a file, producing a non-NotExist error.
+	dir := t.TempDir()
+	if _, err := loadConfig(dir); err == nil {
+		t.Fatal("expected an error reading a directory as a config file, got nil")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -51,6 +51,15 @@ var (
 // @name Authorization
 
 func main() {
+	// Subcommand dispatch: `mowa install [flags]` installs mowa as a launchd
+	// login service and exits. Any other invocation starts the HTTP server.
+	if len(os.Args) > 1 && os.Args[1] == "install" {
+		if err := runInstall(os.Args[2:]); err != nil {
+			log.Fatalf("install failed: %v", err)
+		}
+		return
+	}
+
 	// Parse command line flags
 	var configPath string
 	flag.StringVar(&configPath, "config", "", "Path to configuration file (optional)")

--- a/service.go
+++ b/service.go
@@ -55,6 +55,13 @@ func runInstall(args []string) error {
 		return err
 	}
 
+	// Fail fast if launchd tooling is absent (non-macOS host or a minimal PATH)
+	// before we write any plist or create any directories, so a failed install
+	// leaves nothing behind.
+	if _, err := exec.LookPath("launchctl"); err != nil {
+		return fmt.Errorf("launchctl not found on PATH; `mowa install` requires macOS launchd: %w", err)
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return fmt.Errorf("could not resolve the current user's home directory: %w", err)
@@ -65,18 +72,38 @@ func runInstall(args []string) error {
 	stdoutLog := resolveServicePath(*stdoutFlag, filepath.Join(home, "Library", "Logs", "mowa.out"), home)
 	stderrLog := resolveServicePath(*stderrFlag, filepath.Join(home, "Library", "Logs", "mowa.err"), home)
 
+	// launchd expects absolute paths in ProgramArguments and for its log/config
+	// paths. A "~" has already been expanded; anchor anything still relative
+	// (e.g. a relative os.Executable() or a relative flag value) to the current
+	// working directory so the plist is unambiguous once launchd runs it.
+	for _, p := range []*string{&binaryPath, &configPath, &stdoutLog, &stderrLog} {
+		abs, err := filepath.Abs(*p)
+		if err != nil {
+			return fmt.Errorf("could not resolve %q to an absolute path: %w", *p, err)
+		}
+		*p = abs
+	}
+
+	// The binary must exist and be executable now; otherwise the install
+	// "succeeds" but launchd fails to start the service later with an opaque
+	// error.
+	if err := ensureExecutable(binaryPath); err != nil {
+		return err
+	}
+
 	// Ensure the directories launchd and the config file need exist. The config
 	// file itself is left absent on purpose: loadConfig falls back to defaults
-	// when it is missing, so we must not create or overwrite it here.
+	// when it is missing, so we must not create or overwrite it here. These live
+	// under the user's home, so create them privately (0700).
 	launchAgentsDir := filepath.Join(home, "Library", "LaunchAgents")
 	for _, dir := range []string{launchAgentsDir, filepath.Dir(configPath), filepath.Dir(stdoutLog), filepath.Dir(stderrLog)} {
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0700); err != nil {
 			return fmt.Errorf("failed to create directory %s: %w", dir, err)
 		}
 	}
 
 	plistPath := filepath.Join(launchAgentsDir, launchdLabel+".plist")
-	if err := os.WriteFile(plistPath, []byte(renderLaunchdPlist(binaryPath, configPath, stdoutLog, stderrLog)), 0644); err != nil {
+	if err := os.WriteFile(plistPath, []byte(renderLaunchdPlist(binaryPath, configPath, stdoutLog, stderrLog)), 0600); err != nil {
 		return fmt.Errorf("failed to write launchd plist %s: %w", plistPath, err)
 	}
 	fmt.Printf("Wrote launchd plist to %s\n", plistPath)
@@ -150,7 +177,13 @@ func expandHome(path, home string) string {
 
 // renderLaunchdPlist builds the launchd agent plist. Path values are XML-escaped
 // so a path containing "&" or "<" cannot corrupt the document.
+//
+// WorkingDirectory is set to the config file's directory (an app-specific,
+// writable location). Without it, launchd runs the service from "/", so
+// relative config defaults such as Storage.Dir "./storage" would resolve to
+// "/storage" (unwritable) whenever mowa starts with no config file.
 func renderLaunchdPlist(binaryPath, configPath, stdoutLog, stderrLog string) string {
+	workingDir := filepath.Dir(configPath)
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -163,6 +196,8 @@ func renderLaunchdPlist(binaryPath, configPath, stdoutLog, stderrLog string) str
         <string>-config</string>
         <string>%s</string>
     </array>
+    <key>WorkingDirectory</key>
+    <string>%s</string>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
@@ -177,9 +212,27 @@ func renderLaunchdPlist(binaryPath, configPath, stdoutLog, stderrLog string) str
 		html.EscapeString(launchdLabel),
 		html.EscapeString(binaryPath),
 		html.EscapeString(configPath),
+		html.EscapeString(workingDir),
 		html.EscapeString(stdoutLog),
 		html.EscapeString(stderrLog),
 	)
+}
+
+// ensureExecutable verifies that path points to an existing, non-directory file
+// with at least one executable bit set, so `mowa install` rejects a bad binary
+// path up front instead of letting launchd fail to start the service later.
+func ensureExecutable(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("mowa binary %s is not accessible: %w", path, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("mowa binary %s is a directory, not an executable", path)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		return fmt.Errorf("mowa binary %s is not executable", path)
+	}
+	return nil
 }
 
 // servicePID reports whether the service target is loaded and, if it is running,

--- a/service.go
+++ b/service.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"html"
@@ -42,7 +43,7 @@ var pidLineRegexp = regexp.MustCompile(`(?m)^\s*pid = (\d+)`)
 // separate from the long-running server, reloading a running server is safe —
 // launchd relaunches it from the new plist.
 func runInstall(args []string) error {
-	fs := flag.NewFlagSet("install", flag.ExitOnError)
+	fs := flag.NewFlagSet("install", flag.ContinueOnError)
 	binaryFlag := fs.String("binary", "", "Path to the mowa binary launchd should run (default: the running executable)")
 	configFlag := fs.String("config", "", "Path to the config file passed via -config (default: ~/Library/Application Support/mowa/config.yaml)")
 	stdoutFlag := fs.String("stdout", "", "Path for the service's stdout log (default: ~/Library/Logs/mowa.out)")
@@ -52,6 +53,11 @@ func runInstall(args []string) error {
 		fs.PrintDefaults()
 	}
 	if err := fs.Parse(args); err != nil {
+		// `mowa install -h` is a clean exit, not an install failure; the flag
+		// package has already printed the usage text.
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
 		return err
 	}
 
@@ -103,7 +109,7 @@ func runInstall(args []string) error {
 	}
 
 	plistPath := filepath.Join(launchAgentsDir, launchdLabel+".plist")
-	if err := os.WriteFile(plistPath, []byte(renderLaunchdPlist(binaryPath, configPath, stdoutLog, stderrLog)), 0600); err != nil {
+	if err := writeFileAtomic(plistPath, []byte(renderLaunchdPlist(binaryPath, configPath, stdoutLog, stderrLog)), 0600); err != nil {
 		return fmt.Errorf("failed to write launchd plist %s: %w", plistPath, err)
 	}
 	fmt.Printf("Wrote launchd plist to %s\n", plistPath)
@@ -216,6 +222,33 @@ func renderLaunchdPlist(binaryPath, configPath, stdoutLog, stderrLog string) str
 		html.EscapeString(stdoutLog),
 		html.EscapeString(stderrLog),
 	)
+}
+
+// writeFileAtomic writes data to a temp file in the destination directory and
+// renames it into place, so an interruption (crash, full disk) can never leave
+// a partially-written plist that would make a later `launchctl bootstrap`
+// failure harder to diagnose. The temp file is removed on any error before the
+// rename.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup if we bail out before the rename succeeds.
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
 }
 
 // ensureExecutable verifies that path points to an existing, non-directory file

--- a/service.go
+++ b/service.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"html"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// launchd service constants. The label is fixed so the plist, the launchctl
+// service target, and the reload logic all agree on the same identity.
+const (
+	launchdLabel = "com.mauromorales.mowa"
+
+	// defaultBinaryPath is the fallback binary location used only when the
+	// running executable's path can't be resolved. Normally `mowa install`
+	// points the service at the very binary the user invoked.
+	defaultBinaryPath = "/usr/local/bin/mowa"
+
+	// launchctlTimeout bounds each launchctl invocation so a wedged launchd
+	// can't hang the install command indefinitely.
+	launchctlTimeout = 10 * time.Second
+)
+
+// pidLineRegexp extracts the running pid from `launchctl print` output, whose
+// service dump contains a line like "\tpid = 1234".
+var pidLineRegexp = regexp.MustCompile(`(?m)^\s*pid = (\d+)`)
+
+// runInstall implements `mowa install`: it generates the launchd agent plist,
+// writes it to ~/Library/LaunchAgents/com.mauromorales.mowa.plist, and loads +
+// starts the service so mowa runs at login and stays alive (KeepAlive).
+//
+// It is idempotent: re-running unloads any existing instance of the label and
+// bootstraps the freshly written plist. Because this is a short-lived command
+// separate from the long-running server, reloading a running server is safe —
+// launchd relaunches it from the new plist.
+func runInstall(args []string) error {
+	fs := flag.NewFlagSet("install", flag.ExitOnError)
+	binaryFlag := fs.String("binary", "", "Path to the mowa binary launchd should run (default: the running executable)")
+	configFlag := fs.String("config", "", "Path to the config file passed via -config (default: ~/Library/Application Support/mowa/config.yaml)")
+	stdoutFlag := fs.String("stdout", "", "Path for the service's stdout log (default: ~/Library/Logs/mowa.out)")
+	stderrFlag := fs.String("stderr", "", "Path for the service's stderr log (default: ~/Library/Logs/mowa.err)")
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), "Usage: mowa install [flags]\n\nInstalls mowa as a launchd login service. All flags are optional.\nA leading \"~\" in any path is expanded to your home directory.\n\n")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("could not resolve the current user's home directory: %w", err)
+	}
+
+	binaryPath := resolveServicePath(*binaryFlag, defaultBinaryLocation(), home)
+	configPath := resolveServicePath(*configFlag, filepath.Join(home, "Library", "Application Support", "mowa", "config.yaml"), home)
+	stdoutLog := resolveServicePath(*stdoutFlag, filepath.Join(home, "Library", "Logs", "mowa.out"), home)
+	stderrLog := resolveServicePath(*stderrFlag, filepath.Join(home, "Library", "Logs", "mowa.err"), home)
+
+	// Ensure the directories launchd and the config file need exist. The config
+	// file itself is left absent on purpose: loadConfig falls back to defaults
+	// when it is missing, so we must not create or overwrite it here.
+	launchAgentsDir := filepath.Join(home, "Library", "LaunchAgents")
+	for _, dir := range []string{launchAgentsDir, filepath.Dir(configPath), filepath.Dir(stdoutLog), filepath.Dir(stderrLog)} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", dir, err)
+		}
+	}
+
+	plistPath := filepath.Join(launchAgentsDir, launchdLabel+".plist")
+	if err := os.WriteFile(plistPath, []byte(renderLaunchdPlist(binaryPath, configPath, stdoutLog, stderrLog)), 0644); err != nil {
+		return fmt.Errorf("failed to write launchd plist %s: %w", plistPath, err)
+	}
+	fmt.Printf("Wrote launchd plist to %s\n", plistPath)
+
+	uid := os.Getuid()
+	domainTarget := fmt.Sprintf("gui/%d", uid)
+	serviceTarget := fmt.Sprintf("gui/%d/%s", uid, launchdLabel)
+
+	// Unload any existing instance of the label so bootstrapping a refreshed
+	// plist doesn't fail with "service already bootstrapped".
+	if _, loaded := servicePID(serviceTarget); loaded {
+		if out, err := runLaunchctl("bootout", serviceTarget); err != nil {
+			fmt.Printf("note: %v\n", err)
+			if out != "" {
+				fmt.Println(indent(out))
+			}
+		} else {
+			fmt.Printf("Unloaded the existing service (%s)\n", serviceTarget)
+		}
+	}
+
+	if out, err := runLaunchctl("bootstrap", domainTarget, plistPath); err != nil {
+		if out != "" {
+			return fmt.Errorf("%w\n%s", err, indent(out))
+		}
+		return err
+	}
+
+	fmt.Printf("✅ Installed and started %s\n", launchdLabel)
+	fmt.Printf("   binary: %s\n", binaryPath)
+	fmt.Printf("   config: %s\n", configPath)
+	fmt.Println("   The service will start automatically at login and stay alive (KeepAlive).")
+	fmt.Printf("   Check it with: launchctl print %s\n", serviceTarget)
+	return nil
+}
+
+// defaultBinaryLocation returns the path of the running executable so the
+// installed service points at the same binary the user invoked, falling back
+// to defaultBinaryPath if it can't be resolved.
+func defaultBinaryLocation() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return defaultBinaryPath
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		return resolved
+	}
+	return exe
+}
+
+// resolveServicePath returns the trimmed value (or the fallback when empty) with
+// a leading "~" expanded to the user's home directory.
+func resolveServicePath(value, fallback, home string) string {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		v = fallback
+	}
+	return expandHome(v, home)
+}
+
+// expandHome expands a leading "~" or "~/" in path to the given home directory.
+func expandHome(path, home string) string {
+	if path == "~" {
+		return home
+	}
+	if strings.HasPrefix(path, "~/") {
+		return filepath.Join(home, path[2:])
+	}
+	return path
+}
+
+// renderLaunchdPlist builds the launchd agent plist. Path values are XML-escaped
+// so a path containing "&" or "<" cannot corrupt the document.
+func renderLaunchdPlist(binaryPath, configPath, stdoutLog, stderrLog string) string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>%s</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>%s</string>
+        <string>-config</string>
+        <string>%s</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>%s</string>
+    <key>StandardErrorPath</key>
+    <string>%s</string>
+</dict>
+</plist>
+`,
+		html.EscapeString(launchdLabel),
+		html.EscapeString(binaryPath),
+		html.EscapeString(configPath),
+		html.EscapeString(stdoutLog),
+		html.EscapeString(stderrLog),
+	)
+}
+
+// servicePID reports whether the service target is loaded and, if it is running,
+// its pid. A non-zero launchctl exit means the service is not loaded. A loaded
+// but idle service returns (0, true).
+func servicePID(serviceTarget string) (int, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), launchctlTimeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "launchctl", "print", serviceTarget).CombinedOutput()
+	if err != nil {
+		return 0, false
+	}
+	m := pidLineRegexp.FindSubmatch(out)
+	if m == nil {
+		return 0, true
+	}
+	pid, err := strconv.Atoi(string(m[1]))
+	if err != nil {
+		return 0, true
+	}
+	return pid, true
+}
+
+// runLaunchctl runs a launchctl subcommand with a bounded deadline and returns
+// its trimmed combined output and any error.
+func runLaunchctl(args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), launchctlTimeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "launchctl", args...).CombinedOutput()
+	output := strings.TrimSpace(string(out))
+
+	joined := strings.Join(args, " ")
+	if ctx.Err() == context.DeadlineExceeded {
+		return output, fmt.Errorf("launchctl %s timed out after %s", joined, launchctlTimeout)
+	}
+	if err != nil {
+		return output, fmt.Errorf("launchctl %s failed: %w", joined, err)
+	}
+	return output, nil
+}
+
+// indent prefixes every line of s with two spaces for readable nested output.
+func indent(s string) string {
+	return "  " + strings.ReplaceAll(s, "\n", "\n  ")
+}

--- a/service.go
+++ b/service.go
@@ -153,7 +153,7 @@ func runInstall(args []string) error {
 		return err
 	}
 
-	fmt.Printf("✅ Installed and started %s\n", launchdLabel)
+	fmt.Printf("✅ Installed %s\n", launchdLabel)
 	fmt.Printf("   binary: %s\n", binaryPath)
 	fmt.Printf("   config: %s\n", configPath)
 	if port != "" {
@@ -162,8 +162,46 @@ func runInstall(args []string) error {
 		fmt.Println("   port:   8080 (default; pass --port or set MOWA_PORT to change)")
 	}
 	fmt.Println("   The service will start automatically at login and stay alive (KeepAlive).")
-	fmt.Printf("   Check it with: launchctl print %s\n", serviceTarget)
+
+	// `bootstrap` only means the job was loaded, not that it stayed running — a
+	// job that crashes immediately (e.g. a port conflict) still bootstraps fine.
+	// Give launchd a moment to spawn the process, then report what actually
+	// happened so "Installed" isn't misread as "healthy".
+	pid, loaded := waitForServiceStart(serviceTarget, 2*time.Second)
+	fmt.Print(serviceStatusReport(pid, loaded))
+	fmt.Printf("   Inspect it with: launchctl print %s\n", serviceTarget)
 	return nil
+}
+
+// waitForServiceStart polls the service target until it reports a running pid or
+// the timeout elapses, returning the pid (0 if none) and whether the job is
+// loaded. launchd spawns the process asynchronously after bootstrap, so a brief
+// poll avoids a false "not running" report for a service that is simply still
+// starting.
+func waitForServiceStart(serviceTarget string, timeout time.Duration) (pid int, loaded bool) {
+	deadline := time.Now().Add(timeout)
+	for {
+		pid, loaded = servicePID(serviceTarget)
+		if pid > 0 || time.Now().After(deadline) {
+			return pid, loaded
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// serviceStatusReport renders a one-line status from a service's pid/loaded
+// state after bootstrap: running with a pid, loaded but not (yet) running
+// (likely a startup crash — worth checking logs and port conflicts), or not
+// loaded at all.
+func serviceStatusReport(pid int, loaded bool) string {
+	switch {
+	case pid > 0:
+		return fmt.Sprintf("   status: running (pid %d)\n", pid)
+	case loaded:
+		return "   ⚠️  status: loaded but not running — it likely crashed on startup; check the logs above/below and for a port conflict\n"
+	default:
+		return "   ⚠️  status: not loaded after bootstrap; run the inspect command below to investigate\n"
+	}
 }
 
 // defaultBinaryLocation returns the path of the running executable so the

--- a/service.go
+++ b/service.go
@@ -48,6 +48,7 @@ func runInstall(args []string) error {
 	configFlag := fs.String("config", "", "Path to the config file passed via -config (default: ~/Library/Application Support/mowa/config.yaml)")
 	stdoutFlag := fs.String("stdout", "", "Path for the service's stdout log (default: ~/Library/Logs/mowa.out)")
 	stderrFlag := fs.String("stderr", "", "Path for the service's stderr log (default: ~/Library/Logs/mowa.err)")
+	portFlag := fs.String("port", "", "Port for the service via MOWA_PORT (default: the MOWA_PORT env var at install time, else mowa's built-in 8080)")
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), "Usage: mowa install [flags]\n\nInstalls mowa as a launchd login service. All flags are optional.\nA leading \"~\" in any path is expanded to your home directory.\n\n")
 		fs.PrintDefaults()
@@ -66,6 +67,20 @@ func runInstall(args []string) error {
 	// leaves nothing behind.
 	if _, err := exec.LookPath("launchctl"); err != nil {
 		return fmt.Errorf("launchctl not found on PATH; `mowa install` requires macOS launchd: %w", err)
+	}
+
+	// Resolve the port the service should listen on. An explicit --port wins;
+	// otherwise capture MOWA_PORT from the current environment at install time so
+	// the service matches how the user runs mowa interactively. When neither is
+	// set, the plist omits MOWA_PORT and mowa uses its built-in default (8080).
+	port := strings.TrimSpace(*portFlag)
+	if port == "" {
+		port = strings.TrimSpace(os.Getenv("MOWA_PORT"))
+	}
+	if port != "" {
+		if n, err := strconv.Atoi(port); err != nil || n < 1 || n > 65535 {
+			return fmt.Errorf("invalid port %q: must be a number between 1 and 65535", port)
+		}
 	}
 
 	home, err := os.UserHomeDir()
@@ -109,7 +124,7 @@ func runInstall(args []string) error {
 	}
 
 	plistPath := filepath.Join(launchAgentsDir, launchdLabel+".plist")
-	if err := writeFileAtomic(plistPath, []byte(renderLaunchdPlist(binaryPath, configPath, stdoutLog, stderrLog)), 0600); err != nil {
+	if err := writeFileAtomic(plistPath, []byte(renderLaunchdPlist(binaryPath, configPath, stdoutLog, stderrLog, port)), 0600); err != nil {
 		return fmt.Errorf("failed to write launchd plist %s: %w", plistPath, err)
 	}
 	fmt.Printf("Wrote launchd plist to %s\n", plistPath)
@@ -141,6 +156,11 @@ func runInstall(args []string) error {
 	fmt.Printf("✅ Installed and started %s\n", launchdLabel)
 	fmt.Printf("   binary: %s\n", binaryPath)
 	fmt.Printf("   config: %s\n", configPath)
+	if port != "" {
+		fmt.Printf("   port:   %s (MOWA_PORT)\n", port)
+	} else {
+		fmt.Println("   port:   8080 (default; pass --port or set MOWA_PORT to change)")
+	}
 	fmt.Println("   The service will start automatically at login and stay alive (KeepAlive).")
 	fmt.Printf("   Check it with: launchctl print %s\n", serviceTarget)
 	return nil
@@ -188,8 +208,23 @@ func expandHome(path, home string) string {
 // writable location). Without it, launchd runs the service from "/", so
 // relative config defaults such as Storage.Dir "./storage" would resolve to
 // "/storage" (unwritable) whenever mowa starts with no config file.
-func renderLaunchdPlist(binaryPath, configPath, stdoutLog, stderrLog string) string {
+//
+// When port is non-empty it is exported as MOWA_PORT via EnvironmentVariables so
+// the installed service listens on the same port the user runs mowa with;
+// otherwise the key is omitted and mowa uses its built-in default.
+func renderLaunchdPlist(binaryPath, configPath, stdoutLog, stderrLog, port string) string {
 	workingDir := filepath.Dir(configPath)
+
+	envSection := ""
+	if port != "" {
+		envSection = fmt.Sprintf(`    <key>EnvironmentVariables</key>
+    <dict>
+        <key>MOWA_PORT</key>
+        <string>%s</string>
+    </dict>
+`, html.EscapeString(port))
+	}
+
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -204,7 +239,7 @@ func renderLaunchdPlist(binaryPath, configPath, stdoutLog, stderrLog string) str
     </array>
     <key>WorkingDirectory</key>
     <string>%s</string>
-    <key>RunAtLoad</key>
+%s    <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
     <true/>
@@ -219,6 +254,7 @@ func renderLaunchdPlist(binaryPath, configPath, stdoutLog, stderrLog string) str
 		html.EscapeString(binaryPath),
 		html.EscapeString(configPath),
 		html.EscapeString(workingDir),
+		envSection,
 		html.EscapeString(stdoutLog),
 		html.EscapeString(stderrLog),
 	)
@@ -227,8 +263,10 @@ func renderLaunchdPlist(binaryPath, configPath, stdoutLog, stderrLog string) str
 // writeFileAtomic writes data to a temp file in the destination directory and
 // renames it into place, so an interruption (crash, full disk) can never leave
 // a partially-written plist that would make a later `launchctl bootstrap`
-// failure harder to diagnose. The temp file is removed on any error before the
-// rename.
+// failure harder to diagnose. The temp file's contents are fsynced before the
+// rename and the parent directory is fsynced after, so the write is durable
+// across a crash or power loss rather than only atomic. The temp file is removed
+// on any error before the rename.
 func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
 	if err != nil {
@@ -242,13 +280,40 @@ func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 		tmp.Close()
 		return err
 	}
+	// Flush contents to disk before the rename so a crash can't leave the
+	// renamed file with unwritten (empty/truncated) contents.
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
 	if err := tmp.Close(); err != nil {
 		return err
 	}
 	if err := os.Chmod(tmpName, perm); err != nil {
 		return err
 	}
-	return os.Rename(tmpName, path)
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	// fsync the directory so the rename itself survives a crash.
+	return syncDir(filepath.Dir(path))
+}
+
+// syncDir fsyncs a directory so a rename into it is durable. A directory that
+// cannot be opened or synced (some filesystems disallow it) is treated as a
+// non-fatal best effort.
+func syncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return nil
+	}
+	defer d.Close()
+	if err := d.Sync(); err != nil {
+		// Not all filesystems support directory fsync; the rename already
+		// succeeded, so don't fail the install over durability best-effort.
+		return nil
+	}
+	return nil
 }
 
 // ensureExecutable verifies that path points to an existing, non-directory file

--- a/service_test.go
+++ b/service_test.go
@@ -8,15 +8,18 @@ import (
 )
 
 func TestExpandHome(t *testing.T) {
-	home := "/Users/test"
+	// Build home and expectations with filepath so the test is OS-agnostic:
+	// expandHome joins with filepath.Join, so a hardcoded "/"-joined expectation
+	// would fail on non-Unix builders.
+	home := filepath.FromSlash("/Users/test")
 	cases := []struct {
 		in   string
 		want string
 	}{
 		{"~", home},
-		{"~/Library/Logs/mowa.out", home + "/Library/Logs/mowa.out"},
-		{"/usr/local/bin/mowa", "/usr/local/bin/mowa"},
-		{"~notatilde/foo", "~notatilde/foo"}, // only a leading "~" or "~/" expands
+		{"~/Library/Logs/mowa.out", filepath.Join(home, "Library", "Logs", "mowa.out")},
+		{"/usr/local/bin/mowa", "/usr/local/bin/mowa"}, // no leading "~", returned verbatim
+		{"~notatilde/foo", "~notatilde/foo"},           // only a leading "~" or "~/" expands
 		{"relative/path", "relative/path"},
 	}
 	for _, tc := range cases {
@@ -27,15 +30,15 @@ func TestExpandHome(t *testing.T) {
 }
 
 func TestResolveServicePath(t *testing.T) {
-	home := "/Users/test"
+	home := filepath.FromSlash("/Users/test")
 
 	// Empty value falls back to the default (with the default's ~ expanded).
-	if got := resolveServicePath("  ", "~/Library/Logs/mowa.out", home); got != home+"/Library/Logs/mowa.out" {
+	if got := resolveServicePath("  ", "~/Library/Logs/mowa.out", home); got != filepath.Join(home, "Library", "Logs", "mowa.out") {
 		t.Errorf("empty value did not fall back to expanded default: %q", got)
 	}
 
 	// A provided value overrides the default and has its ~ expanded.
-	if got := resolveServicePath("~/custom.yaml", "/unused", home); got != home+"/custom.yaml" {
+	if got := resolveServicePath("~/custom.yaml", "/unused", home); got != filepath.Join(home, "custom.yaml") {
 		t.Errorf("provided value not expanded: %q", got)
 	}
 
@@ -64,6 +67,60 @@ func TestRenderLaunchdPlist(t *testing.T) {
 		if !strings.Contains(plist, want) {
 			t.Errorf("plist missing %q\n%s", want, plist)
 		}
+	}
+}
+
+func TestWriteFileAtomic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "com.example.test.plist")
+
+	if err := writeFileAtomic(path, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("content = %q, want %q", got, "hello")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("perm = %o, want 600", perm)
+	}
+
+	// Overwriting an existing file works and leaves no stray temp files behind.
+	if err := writeFileAtomic(path, []byte("world"), 0o600); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("expected only the plist to remain, found: %v", names)
+	}
+}
+
+func TestInstallFlagParsing(t *testing.T) {
+	// `-h` is a clean exit (ContinueOnError + flag.ErrHelp), not an install
+	// failure, and it must return before any launchctl/filesystem work.
+	if err := runInstall([]string{"-h"}); err != nil {
+		t.Errorf("runInstall(-h) = %v, want nil", err)
+	}
+
+	// An unknown flag surfaces as a returned error rather than os.Exit.
+	if err := runInstall([]string{"--definitely-not-a-flag"}); err == nil {
+		t.Error("runInstall(--definitely-not-a-flag) = nil, want an error")
 	}
 }
 

--- a/service_test.go
+++ b/service_test.go
@@ -49,7 +49,12 @@ func TestResolveServicePath(t *testing.T) {
 }
 
 func TestRenderLaunchdPlist(t *testing.T) {
-	plist := renderLaunchdPlist("/usr/local/bin/mowa", "/Users/test/config.yaml", "/Users/test/out.log", "/Users/test/err.log")
+	plist := renderLaunchdPlist("/usr/local/bin/mowa", "/Users/test/config.yaml", "/Users/test/out.log", "/Users/test/err.log", "")
+
+	// With no port, the EnvironmentVariables key must be omitted entirely.
+	if strings.Contains(plist, "EnvironmentVariables") || strings.Contains(plist, "MOWA_PORT") {
+		t.Errorf("plist should not mention MOWA_PORT when no port is set:\n%s", plist)
+	}
 
 	for _, want := range []string{
 		"<key>Label</key>",
@@ -156,9 +161,30 @@ func TestEnsureExecutable(t *testing.T) {
 	}
 }
 
+func TestRenderLaunchdPlistWithPort(t *testing.T) {
+	plist := renderLaunchdPlist("/usr/local/bin/mowa", "/Users/test/config.yaml", "/Users/test/out.log", "/Users/test/err.log", "3000")
+	for _, want := range []string{
+		"<key>EnvironmentVariables</key>",
+		"<key>MOWA_PORT</key>",
+		"<string>3000</string>",
+	} {
+		if !strings.Contains(plist, want) {
+			t.Errorf("plist missing %q\n%s", want, plist)
+		}
+	}
+}
+
+func TestInstallRejectsInvalidPort(t *testing.T) {
+	for _, bad := range []string{"0", "-1", "70000", "abc", "80a"} {
+		if err := runInstall([]string{"--port", bad}); err == nil {
+			t.Errorf("runInstall(--port %q) = nil, want an error", bad)
+		}
+	}
+}
+
 func TestRenderLaunchdPlistEscapesPaths(t *testing.T) {
 	// A path with XML metacharacters must not break the document.
-	plist := renderLaunchdPlist("/opt/a&b/mowa", "/c<d>/config.yaml", "/out.log", "/err.log")
+	plist := renderLaunchdPlist("/opt/a&b/mowa", "/c<d>/config.yaml", "/out.log", "/err.log", "")
 	if strings.Contains(plist, "a&b") || strings.Contains(plist, "c<d>") {
 		t.Errorf("plist did not escape XML metacharacters:\n%s", plist)
 	}

--- a/service_test.go
+++ b/service_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -52,6 +54,8 @@ func TestRenderLaunchdPlist(t *testing.T) {
 		"<string>/usr/local/bin/mowa</string>",
 		"<string>-config</string>",
 		"<string>/Users/test/config.yaml</string>",
+		"<key>WorkingDirectory</key>",
+		"<string>/Users/test</string>", // dir of the config path
 		"<key>RunAtLoad</key>",
 		"<key>KeepAlive</key>",
 		"<string>/Users/test/out.log</string>",
@@ -60,6 +64,38 @@ func TestRenderLaunchdPlist(t *testing.T) {
 		if !strings.Contains(plist, want) {
 			t.Errorf("plist missing %q\n%s", want, plist)
 		}
+	}
+}
+
+func TestEnsureExecutable(t *testing.T) {
+	dir := t.TempDir()
+
+	// A regular file with an executable bit passes.
+	exe := filepath.Join(dir, "mowa")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureExecutable(exe); err != nil {
+		t.Errorf("expected executable file to pass, got: %v", err)
+	}
+
+	// A non-existent path fails.
+	if err := ensureExecutable(filepath.Join(dir, "does-not-exist")); err == nil {
+		t.Error("expected missing binary to fail")
+	}
+
+	// A directory fails.
+	if err := ensureExecutable(dir); err == nil {
+		t.Error("expected a directory to fail")
+	}
+
+	// A non-executable regular file fails.
+	plain := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(plain, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureExecutable(plain); err == nil {
+		t.Error("expected non-executable file to fail")
 	}
 }
 

--- a/service_test.go
+++ b/service_test.go
@@ -174,6 +174,22 @@ func TestRenderLaunchdPlistWithPort(t *testing.T) {
 	}
 }
 
+func TestServiceStatusReport(t *testing.T) {
+	if got := serviceStatusReport(1234, true); !strings.Contains(got, "running (pid 1234)") {
+		t.Errorf("running case: %q", got)
+	}
+	// Loaded but no pid → a warning, not a "running" claim.
+	loaded := serviceStatusReport(0, true)
+	if strings.Contains(loaded, "running (pid") || !strings.Contains(loaded, "⚠️") {
+		t.Errorf("loaded-but-not-running case: %q", loaded)
+	}
+	// Not loaded at all → a warning.
+	notLoaded := serviceStatusReport(0, false)
+	if !strings.Contains(notLoaded, "⚠️") || !strings.Contains(notLoaded, "not loaded") {
+		t.Errorf("not-loaded case: %q", notLoaded)
+	}
+}
+
 func TestInstallRejectsInvalidPort(t *testing.T) {
 	for _, bad := range []string{"0", "-1", "70000", "abc", "80a"} {
 		if err := runInstall([]string{"--port", bad}); err == nil {

--- a/service_test.go
+++ b/service_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExpandHome(t *testing.T) {
+	home := "/Users/test"
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"~", home},
+		{"~/Library/Logs/mowa.out", home + "/Library/Logs/mowa.out"},
+		{"/usr/local/bin/mowa", "/usr/local/bin/mowa"},
+		{"~notatilde/foo", "~notatilde/foo"}, // only a leading "~" or "~/" expands
+		{"relative/path", "relative/path"},
+	}
+	for _, tc := range cases {
+		if got := expandHome(tc.in, home); got != tc.want {
+			t.Errorf("expandHome(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestResolveServicePath(t *testing.T) {
+	home := "/Users/test"
+
+	// Empty value falls back to the default (with the default's ~ expanded).
+	if got := resolveServicePath("  ", "~/Library/Logs/mowa.out", home); got != home+"/Library/Logs/mowa.out" {
+		t.Errorf("empty value did not fall back to expanded default: %q", got)
+	}
+
+	// A provided value overrides the default and has its ~ expanded.
+	if got := resolveServicePath("~/custom.yaml", "/unused", home); got != home+"/custom.yaml" {
+		t.Errorf("provided value not expanded: %q", got)
+	}
+
+	// An absolute provided value is used verbatim.
+	if got := resolveServicePath("/opt/mowa", "/unused", home); got != "/opt/mowa" {
+		t.Errorf("absolute value changed: %q", got)
+	}
+}
+
+func TestRenderLaunchdPlist(t *testing.T) {
+	plist := renderLaunchdPlist("/usr/local/bin/mowa", "/Users/test/config.yaml", "/Users/test/out.log", "/Users/test/err.log")
+
+	for _, want := range []string{
+		"<key>Label</key>",
+		"<string>" + launchdLabel + "</string>",
+		"<string>/usr/local/bin/mowa</string>",
+		"<string>-config</string>",
+		"<string>/Users/test/config.yaml</string>",
+		"<key>RunAtLoad</key>",
+		"<key>KeepAlive</key>",
+		"<string>/Users/test/out.log</string>",
+		"<string>/Users/test/err.log</string>",
+	} {
+		if !strings.Contains(plist, want) {
+			t.Errorf("plist missing %q\n%s", want, plist)
+		}
+	}
+}
+
+func TestRenderLaunchdPlistEscapesPaths(t *testing.T) {
+	// A path with XML metacharacters must not break the document.
+	plist := renderLaunchdPlist("/opt/a&b/mowa", "/c<d>/config.yaml", "/out.log", "/err.log")
+	if strings.Contains(plist, "a&b") || strings.Contains(plist, "c<d>") {
+		t.Errorf("plist did not escape XML metacharacters:\n%s", plist)
+	}
+	if !strings.Contains(plist, "a&amp;b") || !strings.Contains(plist, "c&lt;d&gt;") {
+		t.Errorf("expected escaped metacharacters in plist:\n%s", plist)
+	}
+}


### PR DESCRIPTION
Closes #9. Supersedes #13.

Implements issue #9 as a **CLI command** (`mowa install`) rather than the originally-proposed `POST /api/service` endpoint. After discussion, installing a launchd login service is one-time local setup, not a remote operation:

- It's a short-lived command separate from the server, so it **never kills the running server mid-request** and **never contends for the server's port** — both hazards the endpoint had to detect and report.
- It avoids exposing service *persistence* over HTTP (the API has permissive `*` CORS).
- `launchctl bootstrap gui/$UID` wants the user's GUI session context anyway.
- Clean split with self-update: `mowa install` establishes the KeepAlive service once at setup; the `POST /api/update` endpoint relies on it at runtime.

## What it does

```
mowa install [--binary ...] [--config ...] [--stdout ...] [--stderr ...]
```

- Writes `~/Library/LaunchAgents/com.mauromorales.mowa.plist` and loads + starts it with `launchctl bootstrap gui/$UID`.
- `--binary` defaults to the **running executable** (`os.Executable`), so the service points at the same mowa the user invoked. A leading `~` in any path is expanded to the real home dir; the plist uses absolute, XML-escaped paths.
- Ensures `~/Library/LaunchAgents` and the config/log parent dirs exist, but never creates `config.yaml` (defaults apply when absent).
- **Idempotent**: re-running unloads any existing instance of the label and bootstraps the fresh plist.
- All `launchctl` calls run with a bounded 10s timeout.

## Bug fix included

`loadConfig` previously returned an error when handed a config path whose file didn't exist — only an *empty* path fell back to defaults. The installed service points at a possibly-absent `config.yaml`, so it **crash-looped under KeepAlive**. Now a missing file falls back to the built-in defaults (genuine errors like bad permissions are still surfaced). Found via end-to-end testing.

## Testing

- `go vet`, `go test ./...`, `make build` all pass. New unit tests cover `expandHome`, `resolveServicePath`, plist rendering/XML-escaping, and the config-missing-file fallback.
- **Verified live end-to-end on macOS**: `mowa install` → `launchctl print` shows the service loaded with a pid → `curl localhost:8080/api/uptime` returns `200` from the launchd-managed process → re-running reinstalls idempotently → `launchctl bootout` unloads cleanly. Test artifacts were removed afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)