### PR TITLE
Add Reminders API to manage lists and reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Go-native web API server that allows you to interact with MacOS and iCloud fea
 - **Send Messages**: Send iMessages via the Messages app using AppleScript
 - **System Uptime**: Get system uptime using shell commands
 - **File Storage**: Save and retrieve YAML files with configurable storage directory
+- **Reminders**: Manage macOS Reminders lists and reminders (create, list, edit, complete, delete)
 - **Modular Architecture**: Easy to extend with new endpoints for volume control, app launching, etc.
 - **Go Native**: Single binary deployment, no external runtimes required
 - **High Performance**: Compiled Go with Echo web framework
@@ -47,7 +48,7 @@ xattr -d com.apple.quarantine mowa
 **Important**: On first run, macOS may block mowa from running or accessing other applications. You'll need to:
 1. **Allow mowa to run**: Go to System Preferences → Security & Privacy → General, and click "Allow Anyway" for mowa
 2. **Grant accessibility permissions**: Go to System Preferences → Security & Privacy → Privacy → Accessibility, and add mowa to the list of allowed applications
-3. **Grant automation permissions**: For Messages functionality, go to System Preferences → Security & Privacy → Privacy → Automation, and ensure mowa has access to Messages
+3. **Grant automation permissions**: Go to System Preferences → Security & Privacy → Privacy → Automation, and ensure mowa has access to Messages (for messaging) and Reminders (for the reminders endpoints)
 
 ### Option 2: Build from Source
 
@@ -342,6 +343,50 @@ Save YAML files to the configured storage directory. Creates directories automat
 }
 ```
 
+### Reminders
+
+Manage the macOS Reminders app. All routes live under `/api/reminders`.
+
+> [!NOTE]
+> The first Reminders call triggers a macOS **Automation** permission prompt for controlling Reminders (System Settings → Privacy & Security → Automation). You must allow it for these endpoints to work. Reminders scripting can be slow on large databases; the per-call timeout defaults to 30s and is configurable via `reminders.timeout_seconds`.
+
+Lists are addressed by their stable `id`; reminders are always addressed by their stable `id` (names are not unique). When an id appears in the URL path it must be percent-encoded.
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/api/reminders/lists` | List all lists (`name`, `id`) |
+| `POST` | `/api/reminders/lists` | Create a list: `{"name": "..."}` |
+| `DELETE` | `/api/reminders/lists/{id}` | Delete a list and its reminders |
+| `GET` | `/api/reminders/lists/{id}/reminders` | Reminders in a list; `?completed=true` includes completed ones (default: incomplete only) |
+| `POST` | `/api/reminders` | Create: `{"list": "<id or name>", "name": "...", "notes": "...", "due_date": "RFC3339"}` (`notes`/`due_date` optional) |
+| `PATCH` | `/api/reminders/{id}` | Update any of `name`, `notes`, `due_date` (RFC3339), `completed` (bool) |
+| `DELETE` | `/api/reminders/{id}` | Delete a reminder |
+
+**Create a reminder:**
+```json
+{
+  "list": "Groceries",
+  "name": "Buy milk",
+  "notes": "Whole milk, 2 liters",
+  "due_date": "2026-07-20T09:00:00Z"
+}
+```
+
+**Response (201 Created):**
+```json
+{
+  "id": "x-apple-reminder://ABC123",
+  "name": "Buy milk",
+  "notes": "Whole milk, 2 liters",
+  "due_date": "2026-07-20T09:00:00Z",
+  "completed": false,
+  "completion_date": null,
+  "list": "Groceries"
+}
+```
+
+Moving a reminder to another list (the `list` field on `PATCH`) is **not supported** by the macOS Reminders scripting interface and returns `501 Not Implemented`.
+
 ## Development Setup
 
 ### Prerequisites
@@ -445,6 +490,10 @@ messages:
 storage:
   dir: "/Users/foobar/some/path"  # Custom storage directory (optional)
   # Default is "./storage" if not specified
+
+reminders:
+  timeout_seconds: 30  # Max seconds for a single Reminders osascript call (optional)
+  # Default is 30; raise it if Reminders is slow on a large database
 ```
 
 **Important**: Replace the phone numbers and email addresses with your actual contacts. The `config.yaml` file is automatically ignored by git (via `.gitignore`) to protect your privacy.
@@ -535,7 +584,7 @@ go build -ldflags="-s -w" -o mowa
 1. **Permission Denied**: Make sure mowa has been granted the necessary permissions in System Preferences:
    - **General**: Allow mowa to run (Security & Privacy → General)
    - **Accessibility**: Add mowa to allowed applications (Security & Privacy → Privacy → Accessibility)
-   - **Automation**: Grant mowa access to Messages (Security & Privacy → Privacy → Automation)
+   - **Automation**: Grant mowa access to Messages and Reminders (Security & Privacy → Privacy → Automation)
 2. **AppleScript Errors**: Verify that the Messages app is installed and accessible, and that mowa has automation permissions
 3. **Port Already in Use**: Change the port using MOWA_PORT environment variable
 

--- a/config.go
+++ b/config.go
@@ -22,6 +22,9 @@ func loadConfig(configPath string) (*Config, error) {
 			Storage: StorageConfig{
 				Dir: "./storage", // Default storage directory
 			},
+			Reminders: RemindersConfig{
+				TimeoutSeconds: defaultReminderTimeoutSeconds,
+			},
 		}, nil
 	}
 
@@ -52,6 +55,11 @@ func loadConfig(configPath string) (*Config, error) {
 		config.Messages.TimeoutSeconds = defaultSendTimeoutSeconds
 	}
 
+	// Set default reminders timeout if not specified or invalid
+	if config.Reminders.TimeoutSeconds <= 0 {
+		config.Reminders.TimeoutSeconds = defaultReminderTimeoutSeconds
+	}
+
 	log.Printf("Configuration loaded from %s with %d message groups and storage dir: %s", configPath, len(config.Messages.Groups), config.Storage.Dir)
 	return &config, nil
 }
@@ -76,4 +84,4 @@ func expandGroups(recipients []string) []string {
 	}
 
 	return expanded
-} 
+}

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -16,4 +16,11 @@ messages:
 
 storage:
   dir: "/Users/foobar/some/path"  # Custom storage directory
-  # Default is "./storage" if not specified 
+  # Default is "./storage" if not specified
+
+reminders:
+  # Max seconds a single Reminders osascript call may run before it is killed
+  # and reported as an error. Defaults to 30 if unset. Reminders scripting can
+  # be slow on large databases, so this is higher than the messages timeout;
+  # raise it further if your Reminders database is very large.
+  timeout_seconds: 30 

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func main() {
 	e.Use(middleware.Recover())
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 		AllowOrigins: []string{"*"},
-		AllowMethods: []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions},
+		AllowMethods: []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodOptions},
 		AllowHeaders: []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept, echo.HeaderAuthorization},
 	}))
 
@@ -247,6 +247,15 @@ func main() {
 
 		// Self-update endpoint
 		api.POST("/update", handleUpdate)
+
+		// Reminders endpoints - manage macOS Reminders lists and reminders
+		api.GET("/reminders/lists", handleListReminderLists)
+		api.POST("/reminders/lists", handleCreateReminderList)
+		api.DELETE("/reminders/lists/:id", handleDeleteReminderList)
+		api.GET("/reminders/lists/:id/reminders", handleListReminders)
+		api.POST("/reminders", handleCreateReminder)
+		api.PATCH("/reminders/:id", handleUpdateReminder)
+		api.DELETE("/reminders/:id", handleDeleteReminder)
 	}
 
 	// Start server

--- a/messages.go
+++ b/messages.go
@@ -127,20 +127,33 @@ func sendTimeout() time.Duration {
 	return defaultSendTimeoutSeconds * time.Second
 }
 
-// executeAppleScript executes an AppleScript with a bounded deadline and returns
-// any error. The process is killed on timeout so no orphaned osascript lingers.
-func executeAppleScript(script string, timeout time.Duration) error {
-	// Give the process a small grace period beyond the AppleScript's own
-	// `with timeout` so its cleaner error can surface before the hard kill.
+// runOSAScript invokes osascript with the given arguments under a bounded
+// deadline, killing the process on timeout so no orphaned osascript lingers.
+// It returns the combined output, whether the deadline was exceeded, and any
+// exec error. This is the shared low-level runner used by both the Messages
+// AppleScript path (executeAppleScript) and the Reminders JXA path.
+func runOSAScript(timeout time.Duration, args ...string) (output []byte, timedOut bool, err error) {
+	// Give the process a small grace period beyond any in-script `with timeout`
+	// so its cleaner error can surface before the hard kill.
 	ctx, cancel := context.WithTimeout(context.Background(), timeout+2*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "osascript", "-e", script)
+	cmd := exec.CommandContext(ctx, "osascript", args...)
 
-	output, err := cmd.CombinedOutput()
+	output, err = cmd.CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
+		return output, true, fmt.Errorf("osascript timed out after %s", timeout)
+	}
+	return output, false, err
+}
+
+// executeAppleScript executes an AppleScript with a bounded deadline and returns
+// any error. The process is killed on timeout so no orphaned osascript lingers.
+func executeAppleScript(script string, timeout time.Duration) error {
+	output, timedOut, err := runOSAScript(timeout, "-e", script)
+	if timedOut {
 		log.Printf("AppleScript timed out after %s; killed osascript", timeout)
-		return fmt.Errorf("osascript timed out after %s", timeout)
+		return err
 	}
 	if err != nil {
 		log.Printf("AppleScript failed with error: %v", err)

--- a/models.go
+++ b/models.go
@@ -2,8 +2,18 @@ package main
 
 // Config represents the application configuration
 type Config struct {
-	Messages MessagesConfig `yaml:"messages"`
-	Storage  StorageConfig  `yaml:"storage"`
+	Messages  MessagesConfig  `yaml:"messages"`
+	Storage   StorageConfig   `yaml:"storage"`
+	Reminders RemindersConfig `yaml:"reminders"`
+}
+
+// RemindersConfig represents the reminders configuration
+type RemindersConfig struct {
+	// TimeoutSeconds bounds how long a single Reminders osascript call may run
+	// before it is killed and reported as an error. Reminders AppleScript can be
+	// slow on large databases, so this defaults higher than the messages timeout
+	// (defaultReminderTimeoutSeconds).
+	TimeoutSeconds int `yaml:"timeout_seconds"`
 }
 
 // MessagesConfig represents the messages configuration
@@ -112,6 +122,108 @@ type UpdateResponse struct {
 	Message string `json:"message"`
 	// @Description Error message if the update failed
 	Error string `json:"error,omitempty"`
+}
+
+// ReminderList represents a list in the macOS Reminders app
+// @Description A Reminders list
+type ReminderList struct {
+	// @Description The list name
+	// @Example "Groceries"
+	Name string `json:"name"`
+	// @Description Stable identifier for the list (use this to address it unambiguously)
+	// @Example "x-apple-reminderkit://REMCDList/ABC123"
+	ID string `json:"id"`
+}
+
+// ReminderListsResponse wraps the collection of Reminders lists
+// @Description Response containing all Reminders lists
+type ReminderListsResponse struct {
+	// @Description The Reminders lists
+	Lists []ReminderList `json:"lists"`
+}
+
+// Reminder represents a single reminder in the macOS Reminders app
+// @Description A single reminder
+type Reminder struct {
+	// @Description Stable identifier for the reminder; address reminders by this id
+	// @Example "x-apple-reminder://ABC123"
+	ID string `json:"id"`
+	// @Description The reminder title
+	// @Example "Buy milk"
+	Name string `json:"name"`
+	// @Description Free-form notes attached to the reminder
+	// @Example "Whole milk, 2 liters"
+	Notes string `json:"notes"`
+	// @Description Due date in RFC3339 format, or null if none is set
+	// @Example "2026-07-20T09:00:00Z"
+	DueDate *string `json:"due_date"`
+	// @Description Whether the reminder is completed
+	Completed bool `json:"completed"`
+	// @Description Completion date in RFC3339 format, or null if not completed
+	CompletionDate *string `json:"completion_date"`
+	// @Description Name of the list that contains the reminder
+	// @Example "Groceries"
+	List string `json:"list"`
+}
+
+// RemindersResponse wraps the collection of reminders in a list
+// @Description Response containing reminders in a list
+type RemindersResponse struct {
+	// @Description The reminders
+	Reminders []Reminder `json:"reminders"`
+}
+
+// CreateListRequest is the body for creating a Reminders list
+// @Description Request to create a new Reminders list
+type CreateListRequest struct {
+	// @Description The name for the new list
+	// @Example "Groceries"
+	Name string `json:"name" binding:"required"`
+}
+
+// CreateReminderRequest is the body for creating a reminder
+// @Description Request to create a new reminder
+type CreateReminderRequest struct {
+	// @Description The target list, addressed by id or by name
+	// @Example "Groceries"
+	List string `json:"list" binding:"required"`
+	// @Description The reminder title
+	// @Example "Buy milk"
+	Name string `json:"name" binding:"required"`
+	// @Description Optional free-form notes
+	// @Example "Whole milk, 2 liters"
+	Notes string `json:"notes,omitempty"`
+	// @Description Optional due date in RFC3339 format
+	// @Example "2026-07-20T09:00:00Z"
+	DueDate string `json:"due_date,omitempty"`
+}
+
+// UpdateReminderRequest is the body for editing a reminder. Every field is
+// optional; only the fields present in the request are changed.
+// @Description Request to update fields of an existing reminder (all fields optional)
+type UpdateReminderRequest struct {
+	// @Description New title
+	// @Example "Buy oat milk"
+	Name *string `json:"name,omitempty"`
+	// @Description New notes
+	// @Example "Barista edition"
+	Notes *string `json:"notes,omitempty"`
+	// @Description New due date in RFC3339 format
+	// @Example "2026-07-21T09:00:00Z"
+	DueDate *string `json:"due_date,omitempty"`
+	// @Description Mark complete (true) or incomplete (false)
+	Completed *bool `json:"completed,omitempty"`
+	// @Description Move the reminder to another list. Not supported by the macOS
+	// Reminders scripting interface; supplying this returns 501 Not Implemented.
+	List *string `json:"list,omitempty"`
+}
+
+// ReminderErrorResponse is the error body returned by reminders endpoints
+// @Description Error response from a reminders operation
+type ReminderErrorResponse struct {
+	// @Description Human-readable error message
+	// @Example "list not found"
+	Error string `json:"error"`
 }
 
 // MowaError represents custom errors

--- a/reminders.go
+++ b/reminders.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -121,6 +122,20 @@ func reminderError(c echo.Context, opErr *reminderOpError) error {
 	return c.JSON(opErr.Status, ReminderErrorResponse{Error: opErr.Message})
 }
 
+// pathID returns the list/reminder id from a URL path parameter. Ids contain
+// characters such as "://" (e.g. "x-apple-reminder://<uuid>") that a client
+// must percent-encode to keep them within a single path segment. Echo matches
+// on the escaped path and returns the still-encoded segment, so we unescape it
+// here before handing it to the JXA scripts; otherwise "%2F" would never match
+// the literal "/" in the real id and every lookup would 404. A value with no
+// escapes (or an invalid escape) is returned unchanged.
+func pathID(raw string) string {
+	if decoded, err := url.PathUnescape(raw); err == nil {
+		return decoded
+	}
+	return raw
+}
+
 // @Summary List Reminders lists
 // @Description Return every list in the macOS Reminders app with its name and stable id. The first call triggers a macOS Automation (TCC) permission prompt for controlling Reminders. macOS only.
 // @Tags reminders
@@ -179,7 +194,7 @@ func handleCreateReminderList(c echo.Context) error {
 // @Failure 500 {object} ReminderErrorResponse "Internal server error"
 // @Router /api/reminders/lists/{id} [delete]
 func handleDeleteReminderList(c echo.Context) error {
-	id := c.Param("id")
+	id := pathID(c.Param("id"))
 	if id == "" {
 		return c.JSON(http.StatusBadRequest, ReminderErrorResponse{Error: "list id is required"})
 	}
@@ -200,7 +215,7 @@ func handleDeleteReminderList(c echo.Context) error {
 // @Failure 500 {object} ReminderErrorResponse "Internal server error"
 // @Router /api/reminders/lists/{id}/reminders [get]
 func handleListReminders(c echo.Context) error {
-	id := c.Param("id")
+	id := pathID(c.Param("id"))
 	if id == "" {
 		return c.JSON(http.StatusBadRequest, ReminderErrorResponse{Error: "list id is required"})
 	}
@@ -282,7 +297,7 @@ func handleCreateReminder(c echo.Context) error {
 // @Failure 500 {object} ReminderErrorResponse "Internal server error"
 // @Router /api/reminders/{id} [patch]
 func handleUpdateReminder(c echo.Context) error {
-	id := c.Param("id")
+	id := pathID(c.Param("id"))
 	if id == "" {
 		return c.JSON(http.StatusBadRequest, ReminderErrorResponse{Error: "reminder id is required"})
 	}
@@ -346,7 +361,7 @@ func handleUpdateReminder(c echo.Context) error {
 // @Failure 500 {object} ReminderErrorResponse "Internal server error"
 // @Router /api/reminders/{id} [delete]
 func handleDeleteReminder(c echo.Context) error {
-	id := c.Param("id")
+	id := pathID(c.Param("id"))
 	if id == "" {
 		return c.JSON(http.StatusBadRequest, ReminderErrorResponse{Error: "reminder id is required"})
 	}

--- a/reminders.go
+++ b/reminders.go
@@ -1,0 +1,543 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+// defaultReminderTimeoutSeconds bounds a single Reminders osascript call. It is
+// higher than the messages timeout because Reminders scripting can be slow on
+// large databases, but still well under osascript's ~120s default AppleEvent
+// timeout so a wedged Reminders process fails fast instead of hanging the
+// request.
+const defaultReminderTimeoutSeconds = 30
+
+// The Reminders endpoints drive Reminders.app through JavaScript for Automation
+// (JXA) via `osascript -l JavaScript`. Two properties make this robust:
+//
+//   - All caller-supplied input is passed as a single JSON string argument
+//     (argv[0]) and parsed with JSON.parse inside the script, then applied
+//     through the scripting API. User data is never concatenated into the
+//     script text, so there is no AppleScript-injection or quote-escaping
+//     hazard (contrast messages.go, which must escape quotes).
+//   - Each script emits a single JSON envelope via JSON.stringify, so Go parses
+//     structured output instead of splitting delimiter-separated text that
+//     could collide with names/notes containing separators or newlines.
+//
+// The first Reminders call triggers a macOS Automation (TCC) permission prompt;
+// this is documented in the README and the endpoint descriptions below.
+
+// jxaEnvelope is the uniform result every Reminders script returns. Scripts trap
+// their own errors and report them here (with a code) rather than exiting
+// non-zero, so a not-found or unsupported operation is distinguishable from a
+// genuine crash.
+type jxaEnvelope struct {
+	OK    bool            `json:"ok"`
+	Code  string          `json:"code"`
+	Error string          `json:"error"`
+	Data  json.RawMessage `json:"data"`
+}
+
+// reminderOpError carries an HTTP status alongside a client-facing message so
+// handlers can translate a failed script run into the right response.
+type reminderOpError struct {
+	Status  int
+	Message string
+}
+
+// reminderTimeout returns the configured Reminders osascript timeout, falling
+// back to the default when no config is loaded or the value is invalid.
+func reminderTimeout() time.Duration {
+	if appConfig != nil && appConfig.Reminders.TimeoutSeconds > 0 {
+		return time.Duration(appConfig.Reminders.TimeoutSeconds) * time.Second
+	}
+	return defaultReminderTimeoutSeconds * time.Second
+}
+
+// statusForCode maps a script-reported error code to an HTTP status.
+func statusForCode(code string) int {
+	switch code {
+	case "not_found":
+		return http.StatusNotFound
+	case "bad_request":
+		return http.StatusBadRequest
+	case "unsupported":
+		return http.StatusNotImplemented
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// runReminder marshals input to JSON, runs the JXA script with it as argv[0]
+// under a bounded timeout, and decodes the JSON envelope. On success it returns
+// the raw data payload for the caller to unmarshal; otherwise it returns a
+// reminderOpError with the appropriate HTTP status.
+func runReminder(script string, input interface{}) (json.RawMessage, *reminderOpError) {
+	argJSON := "{}"
+	if input != nil {
+		b, err := json.Marshal(input)
+		if err != nil {
+			return nil, &reminderOpError{http.StatusInternalServerError, "failed to encode request"}
+		}
+		argJSON = string(b)
+	}
+
+	timeout := reminderTimeout()
+	output, timedOut, err := runOSAScript(timeout, "-l", "JavaScript", "-e", script, argJSON)
+	if timedOut {
+		log.Printf("Reminders script timed out after %s; killed osascript", timeout)
+		return nil, &reminderOpError{http.StatusInternalServerError, err.Error()}
+	}
+	if err != nil {
+		// A non-zero exit here means the script threw before it could emit an
+		// envelope (e.g. TCC permission denied). Surface the raw output.
+		msg := strings.TrimSpace(string(output))
+		if msg == "" {
+			msg = err.Error()
+		}
+		log.Printf("Reminders script failed: %v; output: %s", err, msg)
+		return nil, &reminderOpError{http.StatusInternalServerError, msg}
+	}
+
+	var env jxaEnvelope
+	if e := json.Unmarshal(bytes.TrimSpace(output), &env); e != nil {
+		log.Printf("Reminders script produced unparseable output: %s", string(output))
+		return nil, &reminderOpError{http.StatusInternalServerError, "failed to parse Reminders output"}
+	}
+	if !env.OK {
+		return nil, &reminderOpError{statusForCode(env.Code), env.Error}
+	}
+	return env.Data, nil
+}
+
+// reminderError writes a reminderOpError as a JSON error response.
+func reminderError(c echo.Context, opErr *reminderOpError) error {
+	return c.JSON(opErr.Status, ReminderErrorResponse{Error: opErr.Message})
+}
+
+// @Summary List Reminders lists
+// @Description Return every list in the macOS Reminders app with its name and stable id. The first call triggers a macOS Automation (TCC) permission prompt for controlling Reminders. macOS only.
+// @Tags reminders
+// @Produce json
+// @Success 200 {object} ReminderListsResponse "Lists retrieved successfully"
+// @Failure 500 {object} ReminderErrorResponse "Internal server error"
+// @Router /api/reminders/lists [get]
+func handleListReminderLists(c echo.Context) error {
+	data, opErr := runReminder(scriptListLists, nil)
+	if opErr != nil {
+		return reminderError(c, opErr)
+	}
+	var lists []ReminderList
+	if err := json.Unmarshal(data, &lists); err != nil {
+		return c.JSON(http.StatusInternalServerError, ReminderErrorResponse{Error: "failed to decode lists"})
+	}
+	return c.JSON(http.StatusOK, ReminderListsResponse{Lists: lists})
+}
+
+// @Summary Create a Reminders list
+// @Description Create a new list in the macOS Reminders app. macOS only.
+// @Tags reminders
+// @Accept json
+// @Produce json
+// @Param request body CreateListRequest true "List to create"
+// @Success 201 {object} ReminderList "List created"
+// @Failure 400 {object} ReminderErrorResponse "Bad request - invalid input"
+// @Failure 500 {object} ReminderErrorResponse "Internal server error"
+// @Router /api/reminders/lists [post]
+func handleCreateReminderList(c echo.Context) error {
+	var req CreateListRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, ReminderErrorResponse{Error: "invalid request body"})
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		return c.JSON(http.StatusBadRequest, ReminderErrorResponse{Error: "name is required"})
+	}
+	data, opErr := runReminder(scriptCreateList, map[string]interface{}{"name": req.Name})
+	if opErr != nil {
+		return reminderError(c, opErr)
+	}
+	var list ReminderList
+	if err := json.Unmarshal(data, &list); err != nil {
+		return c.JSON(http.StatusInternalServerError, ReminderErrorResponse{Error: "failed to decode list"})
+	}
+	return c.JSON(http.StatusCreated, list)
+}
+
+// @Summary Delete a Reminders list
+// @Description Delete a list and all reminders it contains, addressed by its stable id (percent-encode the id in the path). macOS only.
+// @Tags reminders
+// @Produce json
+// @Param id path string true "List id (percent-encoded)"
+// @Success 204 "List deleted"
+// @Failure 404 {object} ReminderErrorResponse "List not found"
+// @Failure 500 {object} ReminderErrorResponse "Internal server error"
+// @Router /api/reminders/lists/{id} [delete]
+func handleDeleteReminderList(c echo.Context) error {
+	id := c.Param("id")
+	if id == "" {
+		return c.JSON(http.StatusBadRequest, ReminderErrorResponse{Error: "list id is required"})
+	}
+	if _, opErr := runReminder(scriptDeleteList, map[string]interface{}{"id": id}); opErr != nil {
+		return reminderError(c, opErr)
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+// @Summary List reminders in a list
+// @Description Return the reminders in a list, addressed by its stable id (percent-encode the id in the path). Completed reminders are excluded unless completed=true. macOS only.
+// @Tags reminders
+// @Produce json
+// @Param id path string true "List id (percent-encoded)"
+// @Param completed query bool false "Include completed reminders (default false)"
+// @Success 200 {object} RemindersResponse "Reminders retrieved successfully"
+// @Failure 404 {object} ReminderErrorResponse "List not found"
+// @Failure 500 {object} ReminderErrorResponse "Internal server error"
+// @Router /api/reminders/lists/{id}/reminders [get]
+func handleListReminders(c echo.Context) error {
+	id := c.Param("id")
+	if id == "" {
+		return c.JSON(http.StatusBadRequest, ReminderErrorResponse{Error: "list id is required"})
+	}
+	includeCompleted := c.QueryParam("completed") == "true"
+	data, opErr := runReminder(scriptListReminders, map[string]interface{}{
+		"id":        id,
+		"completed": includeCompleted,
+	})
+	if opErr != nil {
+		return reminderError(c, opErr)
+	}
+	var reminders []Reminder
+	if err := json.Unmarshal(data, &reminders); err != nil {
+		return c.JSON(http.StatusInternalServerError, ReminderErrorResponse{Error: "failed to decode reminders"})
+	}
+	return c.JSON(http.StatusOK, RemindersResponse{Reminders: reminders})
+}
+
+// @Summary Create a reminder
+// @Description Create a reminder in a list (addressed by id or name). notes and due_date are optional; due_date is RFC3339. macOS only.
+// @Tags reminders
+// @Accept json
+// @Produce json
+// @Param request body CreateReminderRequest true "Reminder to create"
+// @Success 201 {object} Reminder "Reminder created"
+// @Failure 400 {object} ReminderErrorResponse "Bad request - invalid input"
+// @Failure 404 {object} ReminderErrorResponse "List not found"
+// @Failure 500 {object} ReminderErrorResponse "Internal server error"
+// @Router /api/reminders [post]
+func handleCreateReminder(c echo.Context) error {
+	var req CreateReminderRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, ReminderErrorResponse{Error: "invalid request body"})
+	}
+	if strings.TrimSpace(req.List) == "" {
+		return c.JSON(http.StatusBadRequest, ReminderErrorResponse{Error: "list is required"})
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		return c.JSON(http.StatusBadRequest, ReminderErrorResponse{Error: "name is required"})
+	}
+
+	input := map[string]interface{}{
+		"list": req.List,
+		"name": req.Name,
+	}
+	if req.Notes != "" {
+		input["notes"] = req.Notes
+	}
+	if req.DueDate != "" {
+		t, err := time.Parse(time.RFC3339, req.DueDate)
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, ReminderErrorResponse{Error: "due_date must be an RFC3339 timestamp"})
+		}
+		input["due_date"] = t.Format(time.RFC3339)
+	}
+
+	data, opErr := runReminder(scriptCreateReminder, input)
+	if opErr != nil {
+		return reminderError(c, opErr)
+	}
+	var reminder Reminder
+	if err := json.Unmarshal(data, &reminder); err != nil {
+		return c.JSON(http.StatusInternalServerError, ReminderErrorResponse{Error: "failed to decode reminder"})
+	}
+	return c.JSON(http.StatusCreated, reminder)
+}
+
+// @Summary Update a reminder
+// @Description Update any of name, notes, due_date (RFC3339) or completed on a reminder addressed by its stable id (percent-encode the id in the path). Moving a reminder to another list (the list field) is not supported by the macOS Reminders scripting interface and returns 501. macOS only.
+// @Tags reminders
+// @Accept json
+// @Produce json
+// @Param id path string true "Reminder id (percent-encoded)"
+// @Param request body UpdateReminderRequest true "Fields to update"
+// @Success 200 {object} Reminder "Reminder updated"
+// @Failure 400 {object} ReminderErrorResponse "Bad request - invalid input"
+// @Failure 404 {object} ReminderErrorResponse "Reminder not found"
+// @Failure 501 {object} ReminderErrorResponse "Operation not supported (moving between lists)"
+// @Failure 500 {object} ReminderErrorResponse "Internal server error"
+// @Router /api/reminders/{id} [patch]
+func handleUpdateReminder(c echo.Context) error {
+	id := c.Param("id")
+	if id == "" {
+		return c.JSON(http.StatusBadRequest, ReminderErrorResponse{Error: "reminder id is required"})
+	}
+
+	var req UpdateReminderRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, ReminderErrorResponse{Error: "invalid request body"})
+	}
+
+	// Moving a reminder between lists is not supported by the Reminders
+	// scripting interface. Report it honestly rather than faking it.
+	if req.List != nil {
+		return c.JSON(http.StatusNotImplemented, ReminderErrorResponse{
+			Error: "moving a reminder between lists is not supported by the macOS Reminders scripting interface",
+		})
+	}
+
+	input := map[string]interface{}{"id": id}
+	if req.Name != nil {
+		if strings.TrimSpace(*req.Name) == "" {
+			return c.JSON(http.StatusBadRequest, ReminderErrorResponse{Error: "name cannot be empty"})
+		}
+		input["name"] = *req.Name
+	}
+	if req.Notes != nil {
+		input["notes"] = *req.Notes
+	}
+	if req.Completed != nil {
+		input["completed"] = *req.Completed
+	}
+	if req.DueDate != nil {
+		t, err := time.Parse(time.RFC3339, *req.DueDate)
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, ReminderErrorResponse{Error: "due_date must be an RFC3339 timestamp"})
+		}
+		input["due_date"] = t.Format(time.RFC3339)
+	}
+
+	if len(input) == 1 { // only the id
+		return c.JSON(http.StatusBadRequest, ReminderErrorResponse{Error: "no updatable fields provided"})
+	}
+
+	data, opErr := runReminder(scriptUpdateReminder, input)
+	if opErr != nil {
+		return reminderError(c, opErr)
+	}
+	var reminder Reminder
+	if err := json.Unmarshal(data, &reminder); err != nil {
+		return c.JSON(http.StatusInternalServerError, ReminderErrorResponse{Error: "failed to decode reminder"})
+	}
+	return c.JSON(http.StatusOK, reminder)
+}
+
+// @Summary Delete a reminder
+// @Description Delete a reminder addressed by its stable id (percent-encode the id in the path). macOS only.
+// @Tags reminders
+// @Produce json
+// @Param id path string true "Reminder id (percent-encoded)"
+// @Success 204 "Reminder deleted"
+// @Failure 404 {object} ReminderErrorResponse "Reminder not found"
+// @Failure 500 {object} ReminderErrorResponse "Internal server error"
+// @Router /api/reminders/{id} [delete]
+func handleDeleteReminder(c echo.Context) error {
+	id := c.Param("id")
+	if id == "" {
+		return c.JSON(http.StatusBadRequest, ReminderErrorResponse{Error: "reminder id is required"})
+	}
+	if _, opErr := runReminder(scriptDeleteReminder, map[string]interface{}{"id": id}); opErr != nil {
+		return reminderError(c, opErr)
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+// --- JXA scripts -------------------------------------------------------------
+//
+// Each script defines run(argv); osascript prints run's return value. argv[0] is
+// the JSON input. Every script returns a JSON envelope: {ok, data} on success or
+// {ok:false, code, error} on failure. Errors are trapped so the process exits 0
+// and Go can map codes to HTTP statuses.
+
+// remObjFn is a shared JXA helper (inlined into scripts that return a single
+// reminder) that serialises a reminder specifier to the API shape.
+//
+// It reads every scalar field in a single r.properties() round-trip rather than
+// one AppleEvent per property. This matters: on this app, per-property reads of
+// a reminder can take ~30s (enough to trip the request timeout), while a single
+// properties() call plus one container.name() lookup runs in ~10s.
+const remObjFn = `
+function remObj(r) {
+  var p = r.properties();
+  var listName = "";
+  try { listName = p.container.name(); } catch (e) {}
+  return {
+    id: p.id,
+    name: p.name,
+    notes: (p.body === null || p.body === undefined) ? "" : p.body,
+    due_date: p.dueDate ? p.dueDate.toISOString() : null,
+    completed: p.completed,
+    completion_date: p.completionDate ? p.completionDate.toISOString() : null,
+    list: listName
+  };
+}
+`
+
+const scriptListLists = `
+function run(argv) {
+  try {
+    var R = Application('Reminders');
+    var lists = R.lists;
+    var names = lists.name();
+    var ids = lists.id();
+    var out = [];
+    for (var i = 0; i < names.length; i++) {
+      out.push({ name: names[i], id: ids[i] });
+    }
+    return JSON.stringify({ ok: true, data: out });
+  } catch (e) {
+    return JSON.stringify({ ok: false, code: "error", error: String(e) });
+  }
+}
+`
+
+const scriptCreateList = `
+function run(argv) {
+  try {
+    var input = JSON.parse(argv[0] || '{}');
+    var R = Application('Reminders');
+    var l = R.List({ name: input.name });
+    R.lists.push(l);
+    return JSON.stringify({ ok: true, data: { name: l.name(), id: l.id() } });
+  } catch (e) {
+    return JSON.stringify({ ok: false, code: "error", error: String(e) });
+  }
+}
+`
+
+const scriptDeleteList = `
+function run(argv) {
+  try {
+    var input = JSON.parse(argv[0] || '{}');
+    var R = Application('Reminders');
+    var lists = R.lists;
+    var ids = lists.id();
+    var idx = ids.indexOf(input.id);
+    if (idx < 0) {
+      return JSON.stringify({ ok: false, code: "not_found", error: "list not found: " + input.id });
+    }
+    R.delete(lists[idx]);
+    return JSON.stringify({ ok: true, data: {} });
+  } catch (e) {
+    return JSON.stringify({ ok: false, code: "error", error: "failed to delete list: " + String(e) });
+  }
+}
+`
+
+const scriptListReminders = `
+function run(argv) {
+  try {
+    var input = JSON.parse(argv[0] || '{}');
+    var includeCompleted = input.completed === true;
+    var R = Application('Reminders');
+    var lists = R.lists;
+    var ids = lists.id();
+    var idx = ids.indexOf(input.id);
+    if (idx < 0) {
+      return JSON.stringify({ ok: false, code: "not_found", error: "list not found: " + input.id });
+    }
+    var l = lists[idx];
+    var listName = l.name();
+    var rem = l.reminders;
+    var rids = rem.id();
+    var names = rem.name();
+    var bodies = rem.body();
+    var comp = rem.completed();
+    var due = rem.dueDate();
+    var cdate = rem.completionDate();
+    var out = [];
+    for (var i = 0; i < rids.length; i++) {
+      if (!includeCompleted && comp[i]) continue;
+      out.push({
+        id: rids[i],
+        name: names[i],
+        notes: (bodies[i] === null || bodies[i] === undefined) ? "" : bodies[i],
+        due_date: due[i] ? due[i].toISOString() : null,
+        completed: comp[i],
+        completion_date: cdate[i] ? cdate[i].toISOString() : null,
+        list: listName
+      });
+    }
+    return JSON.stringify({ ok: true, data: out });
+  } catch (e) {
+    return JSON.stringify({ ok: false, code: "error", error: String(e) });
+  }
+}
+`
+
+var scriptCreateReminder = remObjFn + `
+function run(argv) {
+  try {
+    var input = JSON.parse(argv[0] || '{}');
+    var R = Application('Reminders');
+    var lists = R.lists;
+    var ids = lists.id();
+    var nms = lists.name();
+    var idx = ids.indexOf(input.list);
+    if (idx < 0) idx = nms.indexOf(input.list);
+    if (idx < 0) {
+      return JSON.stringify({ ok: false, code: "not_found", error: "list not found: " + input.list });
+    }
+    var l = lists[idx];
+    var props = { name: input.name };
+    if (input.notes !== undefined && input.notes !== null) props.body = input.notes;
+    if (input.due_date) props.dueDate = new Date(input.due_date);
+    var r = R.Reminder(props);
+    l.reminders.push(r);
+    return JSON.stringify({ ok: true, data: remObj(r) });
+  } catch (e) {
+    return JSON.stringify({ ok: false, code: "error", error: String(e) });
+  }
+}
+`
+
+var scriptUpdateReminder = remObjFn + `
+function run(argv) {
+  try {
+    var input = JSON.parse(argv[0] || '{}');
+    var R = Application('Reminders');
+    var r = R.reminders.byId(input.id);
+    try { r.name(); } catch (e) {
+      return JSON.stringify({ ok: false, code: "not_found", error: "reminder not found: " + input.id });
+    }
+    if (input.name !== undefined) r.name = input.name;
+    if (input.notes !== undefined) r.body = input.notes;
+    if (input.completed !== undefined) r.completed = input.completed;
+    if (input.due_date !== undefined) r.dueDate = new Date(input.due_date);
+    return JSON.stringify({ ok: true, data: remObj(r) });
+  } catch (e) {
+    return JSON.stringify({ ok: false, code: "error", error: String(e) });
+  }
+}
+`
+
+const scriptDeleteReminder = `
+function run(argv) {
+  try {
+    var input = JSON.parse(argv[0] || '{}');
+    var R = Application('Reminders');
+    var r = R.reminders.byId(input.id);
+    try { r.name(); } catch (e) {
+      return JSON.stringify({ ok: false, code: "not_found", error: "reminder not found: " + input.id });
+    }
+    R.delete(r);
+    return JSON.stringify({ ok: true, data: {} });
+  } catch (e) {
+    return JSON.stringify({ ok: false, code: "error", error: String(e) });
+  }
+}
+`

--- a/reminders_test.go
+++ b/reminders_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+)
+
+// TestStatusForCode verifies the script-code → HTTP-status mapping.
+func TestStatusForCode(t *testing.T) {
+	cases := map[string]int{
+		"not_found":   http.StatusNotFound,
+		"bad_request": http.StatusBadRequest,
+		"unsupported": http.StatusNotImplemented,
+		"error":       http.StatusInternalServerError,
+		"":            http.StatusInternalServerError,
+	}
+	for code, want := range cases {
+		if got := statusForCode(code); got != want {
+			t.Errorf("statusForCode(%q) = %d, want %d", code, got, want)
+		}
+	}
+}
+
+// TestRunReminderSuccess feeds runReminder a trivial JXA script that returns a
+// success envelope. It exercises the JSON-arg passing and envelope decoding
+// without touching the Reminders database, so it is safe to run in CI.
+func TestRunReminderSuccess(t *testing.T) {
+	script := `function run(argv) {
+		var input = JSON.parse(argv[0] || '{}');
+		return JSON.stringify({ ok: true, data: { echo: input.value } });
+	}`
+	data, opErr := runReminder(script, map[string]interface{}{"value": "hello \"world\" \\ and 'quotes'"})
+	if opErr != nil {
+		t.Fatalf("expected success, got error: %+v", opErr)
+	}
+	var out struct {
+		Echo string `json:"echo"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("failed to decode data: %v", err)
+	}
+	// Confirms user input round-trips through the JSON argv without any
+	// escaping/injection mangling.
+	if out.Echo != `hello "world" \ and 'quotes'` {
+		t.Errorf("input not round-tripped, got %q", out.Echo)
+	}
+}
+
+// TestRunReminderError feeds runReminder an error envelope and verifies the
+// code is mapped to the right HTTP status and message. Safe for CI.
+func TestRunReminderError(t *testing.T) {
+	script := `function run(argv) {
+		return JSON.stringify({ ok: false, code: "not_found", error: "nope" });
+	}`
+	_, opErr := runReminder(script, nil)
+	if opErr == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if opErr.Status != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", opErr.Status, http.StatusNotFound)
+	}
+	if opErr.Message != "nope" {
+		t.Errorf("message = %q, want %q", opErr.Message, "nope")
+	}
+}
+
+// TestRemindersLifecycle runs the full create→read→complete→edit→delete
+// lifecycle against the real Reminders app. It is OPT-IN (set
+// MOWA_REMINDERS_LIVE_TEST=1) because it requires macOS Automation permission
+// and would otherwise hang CI on a TCC prompt. Per issue #11's hard constraint,
+// it operates ONLY on a throwaway list it creates, and deletes only that list.
+func TestRemindersLifecycle(t *testing.T) {
+	if os.Getenv("MOWA_REMINDERS_LIVE_TEST") != "1" {
+		t.Skip("set MOWA_REMINDERS_LIVE_TEST=1 to run the live Reminders lifecycle test")
+	}
+
+	listName := fmt.Sprintf("mowa-test-%d", os.Getpid())
+	t.Logf("using throwaway list %q", listName)
+
+	// Create list
+	data, opErr := runReminder(scriptCreateList, map[string]interface{}{"name": listName})
+	if opErr != nil {
+		t.Fatalf("create list: %+v", opErr)
+	}
+	var list ReminderList
+	mustDecode(t, data, &list)
+	if list.Name != listName || list.ID == "" {
+		t.Fatalf("unexpected created list: %+v", list)
+	}
+	// Guarantee cleanup of ONLY the list we created, even on failure.
+	defer func() {
+		if _, err := runReminder(scriptDeleteList, map[string]interface{}{"id": list.ID}); err != nil {
+			t.Errorf("cleanup delete list: %+v", err)
+		}
+	}()
+
+	// Create reminder with notes + due date
+	due := "2026-08-01T09:00:00Z"
+	data, opErr = runReminder(scriptCreateReminder, map[string]interface{}{
+		"list":     list.ID,
+		"name":     "buy milk",
+		"notes":    "2 liters",
+		"due_date": due,
+	})
+	if opErr != nil {
+		t.Fatalf("create reminder: %+v", opErr)
+	}
+	var rem Reminder
+	mustDecode(t, data, &rem)
+	if rem.ID == "" || rem.Name != "buy milk" || rem.Notes != "2 liters" {
+		t.Fatalf("unexpected created reminder: %+v", rem)
+	}
+	if rem.DueDate == nil {
+		t.Fatalf("expected a due date, got nil")
+	}
+
+	// List: incomplete-only should include it
+	assertListCount(t, list.ID, false, 1)
+
+	// Mark complete
+	data, opErr = runReminder(scriptUpdateReminder, map[string]interface{}{
+		"id":        rem.ID,
+		"completed": true,
+	})
+	if opErr != nil {
+		t.Fatalf("complete reminder: %+v", opErr)
+	}
+	mustDecode(t, data, &rem)
+	if !rem.Completed {
+		t.Fatalf("reminder not marked complete: %+v", rem)
+	}
+
+	// Default listing excludes completed; completed=true includes it
+	assertListCount(t, list.ID, false, 0)
+	assertListCount(t, list.ID, true, 1)
+
+	// Edit name, notes and due date
+	data, opErr = runReminder(scriptUpdateReminder, map[string]interface{}{
+		"id":       rem.ID,
+		"name":     "buy oat milk",
+		"notes":    "barista edition",
+		"due_date": "2026-08-02T10:00:00Z",
+	})
+	if opErr != nil {
+		t.Fatalf("edit reminder: %+v", opErr)
+	}
+	mustDecode(t, data, &rem)
+	if rem.Name != "buy oat milk" || rem.Notes != "barista edition" {
+		t.Fatalf("edit did not apply: %+v", rem)
+	}
+
+	// A missing id returns not_found
+	if _, err := runReminder(scriptUpdateReminder, map[string]interface{}{
+		"id":   "x-apple-reminder://does-not-exist",
+		"name": "x",
+	}); err == nil || err.Status != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing reminder, got %+v", err)
+	}
+
+	// Delete the reminder
+	if _, opErr = runReminder(scriptDeleteReminder, map[string]interface{}{"id": rem.ID}); opErr != nil {
+		t.Fatalf("delete reminder: %+v", opErr)
+	}
+	assertListCount(t, list.ID, true, 0)
+}
+
+func assertListCount(t *testing.T, listID string, completed bool, want int) {
+	t.Helper()
+	data, opErr := runReminder(scriptListReminders, map[string]interface{}{
+		"id":        listID,
+		"completed": completed,
+	})
+	if opErr != nil {
+		t.Fatalf("list reminders (completed=%v): %+v", completed, opErr)
+	}
+	var rems []Reminder
+	mustDecode(t, data, &rems)
+	if len(rems) != want {
+		t.Fatalf("list reminders (completed=%v): got %d, want %d", completed, len(rems), want)
+	}
+}
+
+func mustDecode(t *testing.T, data json.RawMessage, v interface{}) {
+	t.Helper()
+	if err := json.Unmarshal(data, v); err != nil {
+		t.Fatalf("decode: %v (raw: %s)", err, string(data))
+	}
+}

--- a/reminders_test.go
+++ b/reminders_test.go
@@ -4,8 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
 )
 
 // TestStatusForCode verifies the script-code → HTTP-status mapping.
@@ -64,6 +69,65 @@ func TestRunReminderError(t *testing.T) {
 	}
 	if opErr.Message != "nope" {
 		t.Errorf("message = %q, want %q", opErr.Message, "nope")
+	}
+}
+
+// TestPathID confirms that a percent-encoded id is unescaped, while values with
+// no escapes pass through unchanged.
+func TestPathID(t *testing.T) {
+	cases := map[string]string{
+		"x-apple-reminder:%2F%2F76211922-212E-4982-87A5-788906F8C0F2": "x-apple-reminder://76211922-212E-4982-87A5-788906F8C0F2",
+		"x-apple-reminderkit:%2F%2FREMCDList%2FABC123":                "x-apple-reminderkit://REMCDList/ABC123",
+		"385881E6-F5E6-4BC2-A0E7-C07E0EDB954D":                        "385881E6-F5E6-4BC2-A0E7-C07E0EDB954D", // bare UUID, no escapes
+	}
+	for in, want := range cases {
+		if got := pathID(in); got != want {
+			t.Errorf("pathID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestReminderIDRoutesThroughEcho verifies the real fix end-to-end: a reminder
+// id containing "://" that a client percent-encodes as a single path segment is
+// routed to the :id handler AND arrives decoded (Echo hands back the still-
+// encoded segment, so the handler must unescape it — which pathID does). Without
+// the fix the handler would receive "%2F" and every lookup would 404. This test
+// touches no Reminders data.
+func TestReminderIDRoutesThroughEcho(t *testing.T) {
+	e := echo.New()
+	var seen string
+	e.DELETE("/api/reminders/:id", func(c echo.Context) error {
+		seen = pathID(c.Param("id"))
+		return c.NoContent(http.StatusNoContent)
+	})
+
+	id := "x-apple-reminder://76211922-212E-4982-87A5-788906F8C0F2"
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/reminders/"+url.PathEscape(id), nil)
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("route did not match encoded id: status=%d", rec.Code)
+	}
+	if seen != id {
+		t.Errorf("handler received %q, want the decoded id %q", seen, id)
+	}
+}
+
+// TestDueDateAcceptsFractionalSeconds documents that RFC3339 due_date values
+// with fractional seconds — which the API itself returns via JXA toISOString()
+// (e.g. "...:00.000Z") — parse successfully, so a client can round-trip a
+// returned due_date back into create/update without a 400.
+func TestDueDateAcceptsFractionalSeconds(t *testing.T) {
+	for _, v := range []string{
+		"2026-08-02T10:00:00Z",
+		"2026-08-02T10:00:00.000Z",
+		"2026-08-02T10:00:00.123456Z",
+		"2026-08-02T10:00:00+02:00",
+	} {
+		if _, err := time.Parse(time.RFC3339, v); err != nil {
+			t.Errorf("time.Parse(RFC3339, %q) rejected a valid value: %v", v, err)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #11.

Adds seven endpoints under `/api/reminders` to drive the macOS Reminders app: list/create/delete lists, list reminders in a list (incomplete by default, `?completed=true` to include completed), and create/update/delete reminders. Updates cover `name`, `notes`, `due_date` and marking complete/incomplete.

## API

| Method | Path | Purpose |
|---|---|---|
| `GET` | `/api/reminders/lists` | List all lists (`name`, `id`) |
| `POST` | `/api/reminders/lists` | Create a list |
| `DELETE` | `/api/reminders/lists/{id}` | Delete a list and its reminders |
| `GET` | `/api/reminders/lists/{id}/reminders` | Reminders in a list; `?completed=true` includes completed |
| `POST` | `/api/reminders` | Create a reminder (list by id or name; `notes`/`due_date` optional) |
| `PATCH` | `/api/reminders/{id}` | Update `name`, `notes`, `due_date`, `completed` |
| `DELETE` | `/api/reminders/{id}` | Delete a reminder |

## Design

- **JXA over classic AppleScript.** Driven via `osascript -l JavaScript`. All caller input is passed as a single JSON argv argument and `JSON.parse`d inside the script, so user data is never concatenated into script text (no AppleScript-injection or quote-escaping hazard), and each script emits a JSON envelope so Go parses structured output instead of splitting delimiter-separated text.
- **Stable ids.** Lists and reminders are addressed by their stable `id`; a missing id returns `404`. URL-path ids must be percent-encoded.
- **Honest 501.** Moving a reminder between lists is unsupported by the Reminders scripting interface, so the `list` field on `PATCH` returns `501 Not Implemented` rather than faking it.
- **Bounded timeout.** The bounded-timeout exec pattern from the Messages path is extracted into a shared `runOSAScript`. Reminders calls default to 30s (configurable via `reminders.timeout_seconds`) since scripting is slow on large databases.
- **Fast readback.** Reminder readback uses a single `properties()` round-trip rather than per-property AppleEvents — this keeps a completed-reminder edit around ~10s instead of ~30s, which was tripping the request timeout.

The first Reminders call triggers a macOS Automation (TCC) prompt; documented in the README and Swagger descriptions.

## Testing

- CI-safe unit tests for the envelope/status logic (run `osascript` but do **not** touch Reminders).
- Opt-in live lifecycle test (`MOWA_REMINDERS_LIVE_TEST=1`) covering create list → create reminder (notes + due date) → list → mark complete → verify default-excludes / `?completed=true`-includes → edit → 404 on missing id → delete reminder → delete list.
- Per issue #11's hard constraint, the live test operates **only** on a throwaway `mowa-test-*` list it creates and cleans up; verified no pre-existing lists/reminders were touched.
- `go build`, `go vet`, `gofmt`, and Swagger regeneration all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)