### PR TITLE
Notify when a restart-required macOS update is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Go-native web API server that allows you to interact with MacOS and iCloud fea
 - **File Storage**: Save and retrieve YAML files with configurable storage directory
 - **Reminders**: Manage macOS Reminders lists and reminders (create, list, edit, complete, delete)
 - **Login Service**: `mowa install` sets mowa up as a launchd agent that starts at login and stays alive
+- **Update Notifications**: a nightly check messages you when a restart-required macOS update is available, so you can keep automatic installs off and install manually
 - **Modular Architecture**: Easy to extend with new endpoints for volume control, app launching, etc.
 - **Go Native**: Single binary deployment, no external runtimes required
 - **High Performance**: Compiled Go with Echo web framework
@@ -175,6 +176,49 @@ tail -f ~/Library/Logs/mowa.out                       # view logs
 
 Running mowa under launchd is also what lets the `POST /api/update` self-update
 endpoint relaunch the process on the new binary.
+
+## macOS Update Notifications
+
+Auto-installed macOS updates reboot into Setup Assistant and de-register
+iMessage, silently breaking every send until someone completes the Apple-ID
+sign-in. The recommended setup is therefore to **disable automatic macOS update
+installs** and let mowa tell you when an update is waiting.
+
+`mowa install` also writes a second, calendar-scheduled agent
+(`~/Library/LaunchAgents/com.mauromorales.mowa-update-check.plist`) that runs
+`mowa check-updates` daily (03:00 by default). The check runs
+`softwareupdate --list` and, when a **restart-required** update (i.e. a macOS
+OS update — Safari and Command Line Tools updates stay silent) is newly
+available, messages the configured recipients:
+
+```
+⬆️ macOS update available on macmini.local — install manually: macOS Tahoe 26.5.2
+```
+
+Each update is announced once (tracked in `update-check-state.json` next to the
+config file); when everything is up to date, nothing is sent. Notifications are
+**off until you configure recipients** in `config.yaml`:
+
+```yaml
+software_update_check:
+  notify:            # phone numbers or group names, like the messaging endpoints
+    - admins
+    - "+1234567890"
+  schedule: "03:00"  # optional, HH:MM local time (default 03:00)
+  # enabled: false   # optional kill switch without removing recipients
+```
+
+The server also re-syncs this agent at startup whenever update checks are
+enabled in the config, so an existing installation picks the agent up after a
+self-update (`POST /api/update`) or a schedule change without re-running
+`mowa install` — no root required, everything stays in the per-user launchd
+domain. Listing updates does not need root either; only installing them does.
+
+```bash
+launchctl print gui/$(id -u)/com.mauromorales.mowa-update-check  # inspect
+tail -f ~/Library/Logs/mowa-update-check.out                     # view logs
+./mowa check-updates -config config.yaml                         # run once by hand
+```
 
 ## API Documentation
 

--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -24,6 +25,10 @@ func defaultConfig() *Config {
 		},
 		Reminders: RemindersConfig{
 			TimeoutSeconds: defaultReminderTimeoutSeconds,
+		},
+		SoftwareUpdateCheck: SoftwareUpdateCheckConfig{
+			Schedule:       defaultUpdateCheckSchedule,
+			TimeoutSeconds: defaultUpdateCheckTimeoutSeconds,
 		},
 	}
 }
@@ -73,6 +78,14 @@ func loadConfig(configPath string) (*Config, error) {
 	// Set default reminders timeout if not specified or invalid
 	if config.Reminders.TimeoutSeconds <= 0 {
 		config.Reminders.TimeoutSeconds = defaultReminderTimeoutSeconds
+	}
+
+	// Set software update check defaults if not specified or invalid
+	if strings.TrimSpace(config.SoftwareUpdateCheck.Schedule) == "" {
+		config.SoftwareUpdateCheck.Schedule = defaultUpdateCheckSchedule
+	}
+	if config.SoftwareUpdateCheck.TimeoutSeconds <= 0 {
+		config.SoftwareUpdateCheck.TimeoutSeconds = defaultUpdateCheckTimeoutSeconds
 	}
 
 	log.Printf("Configuration loaded from %s with %d message groups and storage dir: %s", configPath, len(config.Messages.Groups), config.Storage.Dir)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -23,4 +23,25 @@ reminders:
   # and reported as an error. Defaults to 30 if unset. Reminders scripting can
   # be slow on large databases, so this is higher than the messages timeout;
   # raise it further if your Reminders database is very large.
-  timeout_seconds: 30 
+  timeout_seconds: 30
+
+# Notify when a restart-required macOS update is available, so automatic
+# installs can stay off (they reboot into Setup Assistant and de-register
+# iMessage) and updates are installed manually instead. The check runs daily
+# via the com.mauromorales.mowa-update-check LaunchAgent that `mowa install`
+# sets up, and does nothing unless `notify` has recipients.
+software_update_check:
+  # Optional; defaults to true when notify has recipients. Set to false to
+  # pause notifications without removing the recipients.
+  enabled: true
+  # Who to message, exactly like the messaging endpoints: phone numbers or
+  # group names from messages.groups.
+  notify:
+    - admins
+    - "+1234567890"
+  # Local time of day (HH:MM, 24h) the check runs. Defaults to 03:00. If the
+  # Mac is asleep at that time, launchd runs the check on the next wake.
+  schedule: "03:00"
+  # Max seconds `softwareupdate --list` may run (it scans Apple's servers and
+  # routinely takes 30-60s). Defaults to 300 if unset.
+  timeout_seconds: 300 

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -26,6 +27,57 @@ func TestLoadConfigMissingFileFallsBackToDefaults(t *testing.T) {
 	}
 	if cfg.Messages.Groups == nil {
 		t.Error("expected an initialized (non-nil) groups map")
+	}
+}
+
+// TestLoadConfigSoftwareUpdateCheck ensures the software_update_check section
+// is parsed with the messaging-style notify list, and that omitted fields fall
+// back to defaults.
+func TestLoadConfigSoftwareUpdateCheck(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	yaml := `
+messages:
+  groups:
+    admin:
+      - "+1234567890"
+software_update_check:
+  notify:
+    - admin
+    - "+4915112345678"
+  schedule: "04:30"
+`
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := loadConfig(path)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if !cfg.SoftwareUpdateCheck.isEnabled() {
+		t.Error("expected update check to be enabled when notify has recipients")
+	}
+	if len(cfg.SoftwareUpdateCheck.Notify) != 2 || cfg.SoftwareUpdateCheck.Notify[0] != "admin" {
+		t.Errorf("notify = %v", cfg.SoftwareUpdateCheck.Notify)
+	}
+	if cfg.SoftwareUpdateCheck.Schedule != "04:30" {
+		t.Errorf("schedule = %q, want 04:30", cfg.SoftwareUpdateCheck.Schedule)
+	}
+	if cfg.SoftwareUpdateCheck.TimeoutSeconds != defaultUpdateCheckTimeoutSeconds {
+		t.Errorf("timeout = %d, want default %d", cfg.SoftwareUpdateCheck.TimeoutSeconds, defaultUpdateCheckTimeoutSeconds)
+	}
+
+	// Defaults when the section is absent entirely: disabled, default schedule.
+	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+	def, err := loadConfig(missing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if def.SoftwareUpdateCheck.isEnabled() {
+		t.Error("update check must be disabled by default")
+	}
+	if def.SoftwareUpdateCheck.Schedule != defaultUpdateCheckSchedule {
+		t.Errorf("default schedule = %q, want %q", def.SoftwareUpdateCheck.Schedule, defaultUpdateCheckSchedule)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -52,12 +52,22 @@ var (
 
 func main() {
 	// Subcommand dispatch: `mowa install [flags]` installs mowa as a launchd
-	// login service and exits. Any other invocation starts the HTTP server.
-	if len(os.Args) > 1 && os.Args[1] == "install" {
-		if err := runInstall(os.Args[2:]); err != nil {
-			log.Fatalf("install failed: %v", err)
+	// login service, `mowa check-updates [flags]` runs the scheduled software
+	// update check; both exit when done. Any other invocation starts the HTTP
+	// server.
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "install":
+			if err := runInstall(os.Args[2:]); err != nil {
+				log.Fatalf("install failed: %v", err)
+			}
+			return
+		case "check-updates":
+			if err := runCheckUpdates(os.Args[2:]); err != nil {
+				log.Fatalf("check-updates failed: %v", err)
+			}
+			return
 		}
-		return
 	}
 
 	// Parse command line flags
@@ -70,6 +80,14 @@ func main() {
 	appConfig, err = loadConfig(configPath)
 	if err != nil {
 		log.Fatalf("Failed to load configuration: %v", err)
+	}
+
+	// Self-heal the scheduled update-check agent: after an upgrade (e.g. via
+	// POST /api/update) launchd relaunches this server on the new binary, and
+	// this makes sure the agent exists and matches the config without anyone
+	// re-running `mowa install`. Asynchronous and log-only on failure.
+	if appConfig.SoftwareUpdateCheck.isEnabled() {
+		go ensureUpdateCheckAgentAtStartup(configPath)
 	}
 
 	// Get port from environment variable or use default 8080

--- a/models.go
+++ b/models.go
@@ -2,9 +2,38 @@ package main
 
 // Config represents the application configuration
 type Config struct {
-	Messages  MessagesConfig  `yaml:"messages"`
-	Storage   StorageConfig   `yaml:"storage"`
-	Reminders RemindersConfig `yaml:"reminders"`
+	Messages            MessagesConfig            `yaml:"messages"`
+	Storage             StorageConfig             `yaml:"storage"`
+	Reminders           RemindersConfig           `yaml:"reminders"`
+	SoftwareUpdateCheck SoftwareUpdateCheckConfig `yaml:"software_update_check"`
+}
+
+// SoftwareUpdateCheckConfig configures the nightly `mowa check-updates` run
+// that notifies recipients when a restart-required macOS update is available
+// (issue #17: auto-installed OS updates de-register iMessage, so updates are
+// installed manually and mowa reminds you when one is pending).
+type SoftwareUpdateCheckConfig struct {
+	// Enabled toggles the check. When omitted (nil) the check is enabled as
+	// long as Notify has recipients, so configuring recipients is all that is
+	// needed; an explicit `enabled: false` turns it off without deleting them.
+	Enabled *bool `yaml:"enabled"`
+	// Notify lists who to message about an available update. Entries are phone
+	// numbers or group names, exactly like the `to`/`notify` fields of the
+	// messaging endpoints (groups are expanded via messages.groups).
+	Notify []string `yaml:"notify"`
+	// Schedule is the local time of day ("HH:MM", 24h) the LaunchAgent runs
+	// the check. Defaults to defaultUpdateCheckSchedule (03:00).
+	Schedule string `yaml:"schedule"`
+	// TimeoutSeconds bounds the `softwareupdate --list` call, which hits the
+	// network and can take a minute or more. Defaults to
+	// defaultUpdateCheckTimeoutSeconds.
+	TimeoutSeconds int `yaml:"timeout_seconds"`
+}
+
+// isEnabled reports whether the update check should actually run: there must
+// be someone to notify, and `enabled` must not be explicitly false.
+func (c SoftwareUpdateCheckConfig) isEnabled() bool {
+	return len(c.Notify) > 0 && (c.Enabled == nil || *c.Enabled)
 }
 
 // RemindersConfig represents the reminders configuration

--- a/service.go
+++ b/service.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"html"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,6 +20,11 @@ import (
 // service target, and the reload logic all agree on the same identity.
 const (
 	launchdLabel = "com.mauromorales.mowa"
+
+	// updateCheckLabel is the second, calendar-scheduled agent that runs
+	// `mowa check-updates` (issue #17). Installed by `mowa install` and kept in
+	// sync by the server at startup, so upgrades pick it up without root.
+	updateCheckLabel = "com.mauromorales.mowa-update-check"
 
 	// defaultBinaryPath is the fallback binary location used only when the
 	// running executable's path can't be resolved. Normally `mowa install`
@@ -170,7 +176,173 @@ func runInstall(args []string) error {
 	pid, loaded := waitForServiceStart(serviceTarget, 2*time.Second)
 	fmt.Print(serviceStatusReport(pid, loaded))
 	fmt.Printf("   Inspect it with: launchctl print %s\n", serviceTarget)
+
+	// Also install the update-check agent. It is always installed; whether it
+	// actually notifies is governed by software_update_check in the config, and
+	// `mowa check-updates` exits silently when that is absent. The schedule is
+	// read from the config the service will use.
+	cfg, err := loadConfig(configPath)
+	if err != nil {
+		return fmt.Errorf("could not read config to schedule the update check: %w", err)
+	}
+	changed, err := ensureUpdateCheckAgent(binaryPath, configPath, cfg.SoftwareUpdateCheck.Schedule, home)
+	if err != nil {
+		return fmt.Errorf("failed to install the update-check agent: %w", err)
+	}
+	if changed {
+		fmt.Printf("✅ Installed %s (runs `mowa check-updates` daily at %s)\n", updateCheckLabel, scheduleOrDefault(cfg.SoftwareUpdateCheck.Schedule))
+	} else {
+		fmt.Printf("✅ %s already up to date (runs `mowa check-updates` daily at %s)\n", updateCheckLabel, scheduleOrDefault(cfg.SoftwareUpdateCheck.Schedule))
+	}
+	if !cfg.SoftwareUpdateCheck.isEnabled() {
+		fmt.Println("   Note: update notifications are off until software_update_check.notify is set in the config.")
+	}
 	return nil
+}
+
+// scheduleOrDefault normalizes an empty schedule to the built-in default for
+// display and plist rendering.
+func scheduleOrDefault(schedule string) string {
+	if strings.TrimSpace(schedule) == "" {
+		return defaultUpdateCheckSchedule
+	}
+	return strings.TrimSpace(schedule)
+}
+
+// parseSchedule parses a "HH:MM" (24h) time of day.
+func parseSchedule(schedule string) (hour, minute int, err error) {
+	t, err := time.Parse("15:04", scheduleOrDefault(schedule))
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid software_update_check.schedule %q: want HH:MM (24h), e.g. \"03:00\"", schedule)
+	}
+	return t.Hour(), t.Minute(), nil
+}
+
+// ensureUpdateCheckAgent writes and bootstraps the update-check LaunchAgent,
+// used both by `mowa install` and by the server at startup (so an existing
+// installation gains or re-syncs the agent after an upgrade or a schedule
+// change — everything here stays in the per-user gui domain, no root needed).
+// It is idempotent: when the plist already matches and the job is loaded it
+// does nothing, so a server restart causes no launchd churn. Returns whether
+// anything was (re)installed.
+func ensureUpdateCheckAgent(binaryPath, configPath, schedule, home string) (changed bool, err error) {
+	hour, minute, err := parseSchedule(schedule)
+	if err != nil {
+		return false, err
+	}
+
+	// The agent logs next to nothing, but a scan failure should be findable.
+	stdoutLog := filepath.Join(home, "Library", "Logs", "mowa-update-check.out")
+	stderrLog := filepath.Join(home, "Library", "Logs", "mowa-update-check.err")
+
+	plist := renderUpdateCheckPlist(binaryPath, configPath, stdoutLog, stderrLog, hour, minute)
+	launchAgentsDir := filepath.Join(home, "Library", "LaunchAgents")
+	plistPath := filepath.Join(launchAgentsDir, updateCheckLabel+".plist")
+	serviceTarget := fmt.Sprintf("gui/%d/%s", os.Getuid(), updateCheckLabel)
+
+	existing, readErr := os.ReadFile(plistPath)
+	_, loaded := servicePID(serviceTarget)
+	if readErr == nil && string(existing) == plist && loaded {
+		return false, nil
+	}
+
+	for _, dir := range []string{launchAgentsDir, filepath.Dir(stdoutLog)} {
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			return false, fmt.Errorf("failed to create directory %s: %w", dir, err)
+		}
+	}
+	if err := writeFileAtomic(plistPath, []byte(plist), 0600); err != nil {
+		return false, fmt.Errorf("failed to write launchd plist %s: %w", plistPath, err)
+	}
+
+	if loaded {
+		if out, err := runLaunchctl("bootout", serviceTarget); err != nil {
+			// Non-fatal: bootstrap below reports the real problem if there is one.
+			log.Printf("note: %v\n%s", err, indent(out))
+		}
+	}
+	if out, err := runLaunchctl("bootstrap", fmt.Sprintf("gui/%d", os.Getuid()), plistPath); err != nil {
+		if out != "" {
+			return false, fmt.Errorf("%w\n%s", err, indent(out))
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// ensureUpdateCheckAgentAtStartup is the server-startup self-heal: when the
+// loaded config enables update checks, make sure the scheduled agent exists and
+// matches the config. Runs asynchronously and only logs on failure — a broken
+// launchd interaction must never take the HTTP server down with it.
+func ensureUpdateCheckAgentAtStartup(configPath string) {
+	if _, err := exec.LookPath("launchctl"); err != nil {
+		log.Printf("⚠️ software_update_check is enabled but launchctl is unavailable; cannot schedule the update check: %v", err)
+		return
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		log.Printf("⚠️ could not resolve home directory to schedule the update check: %v", err)
+		return
+	}
+	absConfig, err := filepath.Abs(configPath)
+	if err != nil {
+		log.Printf("⚠️ could not resolve config path to schedule the update check: %v", err)
+		return
+	}
+	changed, err := ensureUpdateCheckAgent(defaultBinaryLocation(), absConfig, appConfig.SoftwareUpdateCheck.Schedule, home)
+	if err != nil {
+		log.Printf("⚠️ could not install the update-check agent: %v", err)
+		return
+	}
+	if changed {
+		log.Printf("✅ Installed %s (runs `mowa check-updates` daily at %s)", updateCheckLabel, scheduleOrDefault(appConfig.SoftwareUpdateCheck.Schedule))
+	}
+}
+
+// renderUpdateCheckPlist builds the calendar-scheduled agent that runs
+// `mowa check-updates` at the given local time. Unlike the server agent it has
+// no RunAtLoad/KeepAlive: launchd starts it at the scheduled time (or on the
+// next wake if the Mac was asleep) and it exits when done. WorkingDirectory
+// matches the server agent so relative paths resolve identically.
+func renderUpdateCheckPlist(binaryPath, configPath, stdoutLog, stderrLog string, hour, minute int) string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>%s</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>%s</string>
+        <string>check-updates</string>
+        <string>-config</string>
+        <string>%s</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>%s</string>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>%d</integer>
+        <key>Minute</key>
+        <integer>%d</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>%s</string>
+    <key>StandardErrorPath</key>
+    <string>%s</string>
+</dict>
+</plist>
+`,
+		html.EscapeString(updateCheckLabel),
+		html.EscapeString(binaryPath),
+		html.EscapeString(configPath),
+		html.EscapeString(filepath.Dir(configPath)),
+		hour,
+		minute,
+		html.EscapeString(stdoutLog),
+		html.EscapeString(stderrLog),
+	)
 }
 
 // waitForServiceStart polls the service target until it reports a running pid or

--- a/updatecheck.go
+++ b/updatecheck.go
@@ -1,0 +1,317 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Software update check constants (issue #17). The check runs as the short-lived
+// `mowa check-updates` subcommand, scheduled by a launchd StartCalendarInterval
+// agent, and messages the configured recipients when a restart-required macOS
+// update is pending so it can be installed manually.
+const (
+	// defaultUpdateCheckSchedule is the local time of day the check runs when
+	// the config does not set software_update_check.schedule. Night-time by
+	// design: quiet, and launchd re-fires a missed interval on wake.
+	defaultUpdateCheckSchedule = "03:00"
+
+	// defaultUpdateCheckTimeoutSeconds bounds `softwareupdate --list`, which
+	// scans Apple's servers and routinely takes 30-60s; nothing is waiting on
+	// the result, so the default is generous.
+	defaultUpdateCheckTimeoutSeconds = 300
+
+	// updateCheckStateFileName holds the labels already notified about, stored
+	// next to the config file so the short-lived subcommand and the server
+	// agree on its location.
+	updateCheckStateFileName = "update-check-state.json"
+)
+
+// availableUpdate is one entry parsed from `softwareupdate --list`.
+type availableUpdate struct {
+	// Label uniquely identifies the update+version (e.g.
+	// "macOS Tahoe 26.5.2-25F84") and is what dedupe state tracks.
+	Label string
+	// Title is the human-readable name (e.g. "macOS Tahoe 26.5.2").
+	Title string
+	// Version as reported by softwareupdate (e.g. "26.5.2").
+	Version string
+	// RestartRequired is true for updates listing "Action: restart" — the OS
+	// updates that reboot into Setup Assistant and break iMessage, which are
+	// the ones worth a notification.
+	RestartRequired bool
+}
+
+// displayName is what the notification shows for an update: the title (which
+// for macOS updates already includes the version), falling back to the label,
+// with the version appended when it isn't already part of the name.
+func (u availableUpdate) displayName() string {
+	name := u.Title
+	if name == "" {
+		name = u.Label
+	}
+	if u.Version != "" && !strings.Contains(name, u.Version) {
+		name += " " + u.Version
+	}
+	return name
+}
+
+// updateCheckState is the JSON persisted between runs to notify once per
+// newly-available update.
+type updateCheckState struct {
+	// NotifiedLabels are the restart-required update labels recipients have
+	// already been messaged about. Labels no longer listed by softwareupdate
+	// (i.e. installed) are pruned each run, so a future re-release of the same
+	// label would notify again.
+	NotifiedLabels []string `json:"notified_labels"`
+}
+
+// runCheckUpdates implements `mowa check-updates`: list available software
+// updates, and message the configured recipients about restart-required ones
+// they have not been told about yet. When software_update_check is not
+// configured (no notify recipients, or enabled: false) it exits silently, so
+// the LaunchAgent can be installed unconditionally.
+func runCheckUpdates(args []string) error {
+	fs := flag.NewFlagSet("check-updates", flag.ContinueOnError)
+	configFlag := fs.String("config", "", "Path to the config file (same flag the server takes)")
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), "Usage: mowa check-updates [flags]\n\nChecks `softwareupdate --list` for restart-required macOS updates and\nmessages the recipients in software_update_check.notify about new ones.\nDoes nothing unless software_update_check is configured.\n\n")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+
+	configPath := strings.TrimSpace(*configFlag)
+	cfg, err := loadConfig(configPath)
+	if err != nil {
+		return err
+	}
+	// sendMessages/expandGroups read the package-level config, exactly like the
+	// server does.
+	appConfig = cfg
+
+	if !cfg.SoftwareUpdateCheck.isEnabled() {
+		log.Printf("software update check is not configured (software_update_check.notify is empty or enabled is false); nothing to do")
+		return nil
+	}
+
+	timeout := time.Duration(cfg.SoftwareUpdateCheck.TimeoutSeconds) * time.Second
+	output, err := listSoftwareUpdates(timeout)
+	if err != nil {
+		return fmt.Errorf("softwareupdate --list failed: %w", err)
+	}
+
+	var restartUpdates []availableUpdate
+	for _, u := range parseSoftwareUpdateList(output) {
+		if u.RestartRequired {
+			restartUpdates = append(restartUpdates, u)
+		}
+	}
+
+	statePath, err := updateCheckStatePath(configPath)
+	if err != nil {
+		return err
+	}
+	state := loadUpdateCheckState(statePath)
+
+	notified := make(map[string]bool, len(state.NotifiedLabels))
+	for _, label := range state.NotifiedLabels {
+		notified[label] = true
+	}
+
+	var fresh []availableUpdate
+	for _, u := range restartUpdates {
+		if !notified[u.Label] {
+			fresh = append(fresh, u)
+		}
+	}
+
+	if len(restartUpdates) == 0 {
+		log.Printf("no restart-required updates available; not notifying")
+	} else if len(fresh) == 0 {
+		log.Printf("all %d restart-required update(s) already notified; not notifying again", len(restartUpdates))
+	}
+
+	sendFailed := false
+	if len(fresh) > 0 {
+		host, err := os.Hostname()
+		if err != nil {
+			host = "this Mac"
+		}
+		message := updateNotificationMessage(host, fresh)
+		log.Printf("notifying %v: %s", cfg.SoftwareUpdateCheck.Notify, message)
+
+		anySuccess := false
+		for _, result := range sendMessages(expandGroups(cfg.SoftwareUpdateCheck.Notify), message) {
+			if result.Success {
+				anySuccess = true
+			} else if result.Error != nil {
+				log.Printf("⚠️ failed to notify %s: %s", result.Recipient, *result.Error)
+			}
+		}
+		// Only record the labels once someone actually received the message, so
+		// a completely failed send is retried on the next scheduled run.
+		if anySuccess {
+			for _, u := range fresh {
+				notified[u.Label] = true
+			}
+		} else {
+			sendFailed = true
+		}
+	}
+
+	// Persist the notified labels that are still pending; anything no longer
+	// listed has been installed and is dropped.
+	var stillPending []string
+	for _, u := range restartUpdates {
+		if notified[u.Label] {
+			stillPending = append(stillPending, u.Label)
+		}
+	}
+	sort.Strings(stillPending)
+	if err := saveUpdateCheckState(statePath, updateCheckState{NotifiedLabels: stillPending}); err != nil {
+		return fmt.Errorf("failed to save update-check state: %w", err)
+	}
+
+	if sendFailed {
+		return fmt.Errorf("update notification could not be delivered to any recipient")
+	}
+	return nil
+}
+
+// listSoftwareUpdates runs `softwareupdate --list` under a bounded deadline and
+// returns its combined output. The command hits Apple's update servers, so the
+// deadline keeps a stuck scan from wedging the scheduled job.
+func listSoftwareUpdates(timeout time.Duration) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "softwareupdate", "--list").CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return string(out), fmt.Errorf("timed out after %s", timeout)
+	}
+	if err != nil {
+		return string(out), fmt.Errorf("%w\n%s", err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
+// parseSoftwareUpdateList parses the modern (macOS 12+) `softwareupdate --list`
+// format:
+//
+//   - Label: macOS Tahoe 26.5.2-25F84
+//     Title: macOS Tahoe 26.5.2, Version: 26.5.2, Size: 3709215KiB, Recommended: YES, Action: restart,
+//
+// "No new software available." (and any unrecognized output) yields no updates.
+func parseSoftwareUpdateList(output string) []availableUpdate {
+	var updates []availableUpdate
+	lines := strings.Split(output, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "* Label:") {
+			continue
+		}
+		u := availableUpdate{Label: strings.TrimSpace(strings.TrimPrefix(trimmed, "* Label:"))}
+		if i+1 < len(lines) {
+			if detail := strings.TrimSpace(lines[i+1]); strings.HasPrefix(detail, "Title:") {
+				u.Title, u.Version, u.RestartRequired = parseUpdateDetail(detail)
+			}
+		}
+		updates = append(updates, u)
+	}
+	return updates
+}
+
+// parseUpdateDetail parses the comma-separated "Key: value" detail line under a
+// label. Apple's own titles ("macOS Tahoe 26.5.2", "Command Line Tools for
+// Xcode 26.6") contain no commas; a hypothetical comma in a title would only
+// truncate that title, never misparse the restart flag.
+func parseUpdateDetail(detail string) (title, version string, restart bool) {
+	for _, part := range strings.Split(detail, ",") {
+		part = strings.TrimSpace(part)
+		switch {
+		case strings.HasPrefix(part, "Title:"):
+			title = strings.TrimSpace(strings.TrimPrefix(part, "Title:"))
+		case strings.HasPrefix(part, "Version:"):
+			version = strings.TrimSpace(strings.TrimPrefix(part, "Version:"))
+		case strings.HasPrefix(part, "Action:"):
+			restart = strings.EqualFold(strings.TrimSpace(strings.TrimPrefix(part, "Action:")), "restart")
+		}
+	}
+	return title, version, restart
+}
+
+// updateNotificationMessage builds the iMessage text for newly-available
+// restart-required updates. The leading ⬆️ identifies upgrade notifications
+// at a glance (issue #17).
+func updateNotificationMessage(host string, updates []availableUpdate) string {
+	names := make([]string, 0, len(updates))
+	for _, u := range updates {
+		names = append(names, u.displayName())
+	}
+	noun := "update"
+	if len(updates) > 1 {
+		noun = "updates"
+	}
+	return fmt.Sprintf("⬆️ macOS %s available on %s — install manually: %s", noun, host, strings.Join(names, ", "))
+}
+
+// updateCheckStatePath places the dedupe state next to the config file, which
+// is the one location both the scheduled subcommand and the server can derive
+// identically. The check is only enabled through a config file, so configPath
+// is always non-empty here; the empty case is a defensive error.
+func updateCheckStatePath(configPath string) (string, error) {
+	if strings.TrimSpace(configPath) == "" {
+		return "", fmt.Errorf("cannot locate update-check state without a config path")
+	}
+	abs, err := filepath.Abs(configPath)
+	if err != nil {
+		return "", fmt.Errorf("could not resolve config path %q: %w", configPath, err)
+	}
+	return filepath.Join(filepath.Dir(abs), updateCheckStateFileName), nil
+}
+
+// loadUpdateCheckState reads the persisted state, treating a missing or
+// unreadable file as "nothing notified yet" — the worst case is one repeated
+// notification, which beats failing the whole check.
+func loadUpdateCheckState(path string) updateCheckState {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			log.Printf("⚠️ could not read update-check state %s (%v); assuming nothing notified", path, err)
+		}
+		return updateCheckState{}
+	}
+	var state updateCheckState
+	if err := json.Unmarshal(data, &state); err != nil {
+		log.Printf("⚠️ could not parse update-check state %s (%v); assuming nothing notified", path, err)
+		return updateCheckState{}
+	}
+	return state
+}
+
+// saveUpdateCheckState persists the state atomically so a crash mid-write can't
+// corrupt it into re-notification loops.
+func saveUpdateCheckState(path string, state updateCheckState) error {
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	return writeFileAtomic(path, append(data, '\n'), 0600)
+}

--- a/updatecheck_test.go
+++ b/updatecheck_test.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// realSoftwareUpdateOutput is verbatim `softwareupdate --list` output captured
+// on macOS 26 (Tahoe): two non-restart Command Line Tools updates and one
+// restart-required OS update.
+const realSoftwareUpdateOutput = `Software Update Tool
+
+Finding available software
+Software Update found the following new or updated software:
+* Label: Command Line Tools for Xcode 26.5-26.5
+	Title: Command Line Tools for Xcode 26.5, Version: 26.5, Size: 920416KiB, Recommended: YES,
+* Label: Command Line Tools for Xcode 26.6-26.6
+	Title: Command Line Tools for Xcode 26.6, Version: 26.6, Size: 920431KiB, Recommended: YES,
+* Label: macOS Tahoe 26.5.2-25F84
+	Title: macOS Tahoe 26.5.2, Version: 26.5.2, Size: 3709215KiB, Recommended: YES, Action: restart,
+`
+
+func TestParseSoftwareUpdateList(t *testing.T) {
+	updates := parseSoftwareUpdateList(realSoftwareUpdateOutput)
+	if len(updates) != 3 {
+		t.Fatalf("parsed %d updates, want 3: %+v", len(updates), updates)
+	}
+
+	clt := updates[0]
+	if clt.Label != "Command Line Tools for Xcode 26.5-26.5" {
+		t.Errorf("label = %q", clt.Label)
+	}
+	if clt.Title != "Command Line Tools for Xcode 26.5" || clt.Version != "26.5" {
+		t.Errorf("title/version = %q/%q", clt.Title, clt.Version)
+	}
+	if clt.RestartRequired {
+		t.Error("Command Line Tools update must not be restart-required")
+	}
+
+	macos := updates[2]
+	if macos.Label != "macOS Tahoe 26.5.2-25F84" {
+		t.Errorf("label = %q", macos.Label)
+	}
+	if macos.Title != "macOS Tahoe 26.5.2" || macos.Version != "26.5.2" {
+		t.Errorf("title/version = %q/%q", macos.Title, macos.Version)
+	}
+	if !macos.RestartRequired {
+		t.Error("macOS update must be restart-required (Action: restart)")
+	}
+}
+
+func TestParseSoftwareUpdateListNoUpdates(t *testing.T) {
+	for name, output := range map[string]string{
+		"no new software": "Software Update Tool\n\nFinding available software\nNo new software available.\n",
+		"empty":           "",
+		"garbage":         "could not connect to the update server\n",
+	} {
+		if updates := parseSoftwareUpdateList(output); len(updates) != 0 {
+			t.Errorf("%s: parsed %d updates, want 0", name, len(updates))
+		}
+	}
+}
+
+func TestDisplayName(t *testing.T) {
+	cases := []struct {
+		u    availableUpdate
+		want string
+	}{
+		// Title already contains the version: no duplication.
+		{availableUpdate{Label: "macOS Tahoe 26.5.2-25F84", Title: "macOS Tahoe 26.5.2", Version: "26.5.2"}, "macOS Tahoe 26.5.2"},
+		// Version missing from the title: appended.
+		{availableUpdate{Label: "Safari-x", Title: "Safari", Version: "17.5"}, "Safari 17.5"},
+		// No title: fall back to the label.
+		{availableUpdate{Label: "SomeLabel-1.0", Version: "1.0"}, "SomeLabel-1.0"},
+	}
+	for _, tc := range cases {
+		if got := tc.u.displayName(); got != tc.want {
+			t.Errorf("displayName(%+v) = %q, want %q", tc.u, got, tc.want)
+		}
+	}
+}
+
+func TestUpdateNotificationMessage(t *testing.T) {
+	one := updateNotificationMessage("macmini.local", []availableUpdate{
+		{Title: "macOS Tahoe 26.5.2", Version: "26.5.2"},
+	})
+	// The user-specified format: leading ⬆️, host, and the update name.
+	if !strings.HasPrefix(one, "⬆️ ") {
+		t.Errorf("message must start with ⬆️: %q", one)
+	}
+	for _, want := range []string{"macmini.local", "macOS Tahoe 26.5.2", "install manually"} {
+		if !strings.Contains(one, want) {
+			t.Errorf("message missing %q: %q", want, one)
+		}
+	}
+
+	two := updateNotificationMessage("h", []availableUpdate{
+		{Title: "macOS Tahoe 26.5.2", Version: "26.5.2"},
+		{Title: "macOS Tahoe 26.6", Version: "26.6"},
+	})
+	if !strings.Contains(two, "updates available") || !strings.Contains(two, "macOS Tahoe 26.5.2, macOS Tahoe 26.6") {
+		t.Errorf("multi-update message wrong: %q", two)
+	}
+}
+
+func TestUpdateCheckStateRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state", updateCheckStateFileName)
+
+	// A missing file is an empty state, not an error.
+	if state := loadUpdateCheckState(path); len(state.NotifiedLabels) != 0 {
+		t.Errorf("missing file: state = %+v, want empty", state)
+	}
+
+	want := updateCheckState{NotifiedLabels: []string{"macOS Tahoe 26.5.2-25F84"}}
+	if err := saveUpdateCheckState(path, want); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got := loadUpdateCheckState(path)
+	if len(got.NotifiedLabels) != 1 || got.NotifiedLabels[0] != want.NotifiedLabels[0] {
+		t.Errorf("state = %+v, want %+v", got, want)
+	}
+
+	// A corrupt file degrades to an empty state instead of failing the check.
+	if err := os.WriteFile(path, []byte("{not json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if state := loadUpdateCheckState(path); len(state.NotifiedLabels) != 0 {
+		t.Errorf("corrupt file: state = %+v, want empty", state)
+	}
+}
+
+func TestUpdateCheckStatePath(t *testing.T) {
+	got, err := updateCheckStatePath("/Users/test/Library/Application Support/mowa/config.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join("/Users/test/Library/Application Support/mowa", updateCheckStateFileName)
+	if got != want {
+		t.Errorf("statePath = %q, want %q", got, want)
+	}
+
+	// Without a config path there is no well-defined state location.
+	if _, err := updateCheckStatePath("  "); err == nil {
+		t.Error("expected an error for an empty config path")
+	}
+}
+
+func TestSoftwareUpdateCheckIsEnabled(t *testing.T) {
+	off := false
+	on := true
+	cases := []struct {
+		name string
+		cfg  SoftwareUpdateCheckConfig
+		want bool
+	}{
+		{"zero config", SoftwareUpdateCheckConfig{}, false},
+		{"notify only", SoftwareUpdateCheckConfig{Notify: []string{"admin"}}, true},
+		{"explicitly disabled", SoftwareUpdateCheckConfig{Notify: []string{"admin"}, Enabled: &off}, false},
+		{"explicitly enabled", SoftwareUpdateCheckConfig{Notify: []string{"admin"}, Enabled: &on}, true},
+		{"enabled but nobody to notify", SoftwareUpdateCheckConfig{Enabled: &on}, false},
+	}
+	for _, tc := range cases {
+		if got := tc.cfg.isEnabled(); got != tc.want {
+			t.Errorf("%s: isEnabled() = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestParseSchedule(t *testing.T) {
+	cases := []struct {
+		in           string
+		hour, minute int
+	}{
+		{"", 3, 0}, // empty falls back to the 03:00 default
+		{"03:00", 3, 0},
+		{"23:59", 23, 59},
+		{"00:00", 0, 0},
+	}
+	for _, tc := range cases {
+		hour, minute, err := parseSchedule(tc.in)
+		if err != nil {
+			t.Errorf("parseSchedule(%q): %v", tc.in, err)
+			continue
+		}
+		if hour != tc.hour || minute != tc.minute {
+			t.Errorf("parseSchedule(%q) = %d:%d, want %d:%d", tc.in, hour, minute, tc.hour, tc.minute)
+		}
+	}
+
+	for _, bad := range []string{"24:00", "3pm", "03:60", "3:0:0", "nightly"} {
+		if _, _, err := parseSchedule(bad); err == nil {
+			t.Errorf("parseSchedule(%q) = nil error, want an error", bad)
+		}
+	}
+}
+
+func TestRenderUpdateCheckPlist(t *testing.T) {
+	plist := renderUpdateCheckPlist("/usr/local/bin/mowa", "/Users/test/config.yaml", "/Users/test/out.log", "/Users/test/err.log", 3, 30)
+
+	for _, want := range []string{
+		"<string>" + updateCheckLabel + "</string>",
+		"<string>/usr/local/bin/mowa</string>",
+		"<string>check-updates</string>",
+		"<string>-config</string>",
+		"<string>/Users/test/config.yaml</string>",
+		"<key>StartCalendarInterval</key>",
+		"<integer>3</integer>",
+		"<integer>30</integer>",
+		"<string>/Users/test/out.log</string>",
+		"<string>/Users/test/err.log</string>",
+	} {
+		if !strings.Contains(plist, want) {
+			t.Errorf("plist missing %q\n%s", want, plist)
+		}
+	}
+
+	// A scheduled one-shot must not keep itself alive or run at load.
+	if strings.Contains(plist, "KeepAlive") || strings.Contains(plist, "RunAtLoad") {
+		t.Errorf("update-check plist must not contain KeepAlive/RunAtLoad:\n%s", plist)
+	}
+}
+
+func TestCheckUpdatesFlagParsing(t *testing.T) {
+	// `-h` is a clean exit, mirroring `mowa install -h`.
+	if err := runCheckUpdates([]string{"-h"}); err != nil {
+		t.Errorf("runCheckUpdates(-h) = %v, want nil", err)
+	}
+	if err := runCheckUpdates([]string{"--definitely-not-a-flag"}); err == nil {
+		t.Error("runCheckUpdates(--definitely-not-a-flag) = nil, want an error")
+	}
+}
+
+func TestCheckUpdatesUnconfiguredIsNoop(t *testing.T) {
+	// With no config (defaults: no notify recipients) the subcommand must exit
+	// cleanly without shelling out to softwareupdate or writing any state.
+	prev := appConfig
+	defer func() { appConfig = prev }()
+	if err := runCheckUpdates(nil); err != nil {
+		t.Errorf("runCheckUpdates with no config = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
Closes #17.

Implements **approach A** from the issue (per the follow-up comment): a second, calendar-scheduled LaunchAgent set up by `mowa install`, with the comment's requests folded in.

## What it does

- New `mowa check-updates` subcommand runs `softwareupdate --list` (bounded by a configurable timeout, default 300s) and messages the configured recipients when a **restart-required** update — the macOS OS updates that reboot into Setup Assistant and de-register iMessage — is newly available. Safari/Command Line Tools updates stay silent.
- Message format (leading upgrade emoji as requested): `⬆️ macOS update available on stardust — install manually: macOS Tahoe 26.5.2`
- **No updates → no notification.** Each update is announced once: notified labels persist in `update-check-state.json` next to the config file and are pruned once the update is installed. A completely failed send is *not* recorded, so it retries the next night.
- `mowa install` now also writes `com.mauromorales.mowa-update-check.plist` (`StartCalendarInterval`, 03:00 default; launchd fires a missed interval on the next wake).

## Config — messaging-shaped recipients, as requested

```yaml
software_update_check:
  notify:            # phone numbers or group names, exactly like the messaging endpoints
    - admins
    - "+1234567890"
  schedule: "03:00"  # optional, HH:MM local time
  # enabled: false   # optional kill switch
```

Off unless `notify` has recipients — the agent is installed unconditionally but `check-updates` exits silently when unconfigured, so there are no surprise 3am sends.

## Upgrade path without root — validated

The comment asked to validate whether an existing installation can gain the new launch config without root. **It can**: the plist lives in `~/Library/LaunchAgents` and `launchctl bootstrap gui/$UID` operates in the per-user domain; both verified live on macOS 26 with no privilege escalation. To make upgrades hands-off, the server re-syncs the agent at startup whenever the config enables update checks — so after a self-update (`POST /api/update`), launchd relaunches the server on the new binary and the agent appears/updates automatically, no `mowa install` re-run needed. The sync is idempotent (no launchd churn when the plist already matches) and log-only on failure.

## Verified end-to-end on macOS 26

- Real `softwareupdate --list` run: correctly picked out `macOS Tahoe 26.5.2` (`Action: restart`) and ignored two CLT updates; built the ⬆️ message; failed sends kept out of state for retry.
- Dedupe: pre-seeded state → "already notified", no send; stale labels pruned.
- Full `mowa install` → both agents written and bootstrapped; `launchctl kickstart` of the check agent ran the check via launchd with correct logs.
- Upgrade simulation: removed the agent, restarted the server → agent self-healed. Schedule change in config → plist re-synced on restart. Invalid schedule (`25:00`) → warning logged, server unaffected.
- All launchd artifacts from verification were removed afterwards.

No new HTTP endpoints, so no Swagger regeneration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ovxVtwc8hYPTHXTmaA5Em